### PR TITLE
remove port config setting and improve documentation

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -32,10 +32,9 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   default :codec, "json"
 
   # List of elasticsearch hosts to use for querying.
+  # each host can be either IP, HOST, IP:port or HOST:port
+  # port defaults to 9200
   config :hosts, :validate => :array
-
-  # The HTTP port of your Elasticsearch server's REST interface.
-  config :port, :validate => :number, :default => 9200
 
   # The index or alias to search.
   config :index, :validate => :string, :default => "logstash-*"

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -67,7 +67,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # [source, ruby]
   #     input {
   #       elasticsearch {
-  #         host => "es.production.mysite.org"
+  #         hosts => "es.production.mysite.org"
   #         index => "mydata-2018.09.*"
   #         query => "*"
   #         size => 500


### PR DESCRIPTION
removes port setting since you can specify host:port in the "hosts" config parameter

addresses #16 