### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -156,7 +156,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
       has_hits = r['hits']['hits'].any?
     end
 
-    while has_hits do
+    while has_hits && !stop?
       r = process_next_scroll(output_queue, r['_scroll_id'])
       has_hits = r['has_hits']
     end

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -4,6 +4,25 @@ require "logstash/inputs/elasticsearch"
 require "elasticsearch"
 
 describe LogStash::Inputs::Elasticsearch do
+
+  it_behaves_like "an interruptible input plugin" do
+    let(:esclient) { double("elasticsearch-client") }
+    let(:config) { { } }
+
+    before :each do
+      allow(Elasticsearch::Client).to receive(:new).and_return(esclient)
+      hit = {
+        "_index" => "logstash-2014.10.12",
+        "_type" => "logs",
+        "_id" => "C5b2xLQwTZa76jBmHIbwHQ",
+        "_score" => 1.0,
+        "_source" => { "message" => ["ohayo"] }
+      }
+      allow(esclient).to receive(:search) { { "hits" => { "hits" => [hit] } } }
+      allow(esclient).to receive(:scroll) { { "hits" => { "hits" => [hit] } } }
+    end
+  end
+
   it "should retrieve json event from elasticseach" do
     config = %q[
       input {


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812