### PR TITLE
Updated faulty documentation of query usage.

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -69,7 +69,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   #       elasticsearch {
   #         hosts => "es.production.mysite.org"
   #         index => "mydata-2018.09.*"
-  #         query => "*"
+  #         query => '{"query": { "match_all": {} } }'
   #         size => 500
   #         scroll => "5m"
   #         docinfo => true


### PR DESCRIPTION
Using "*" as query will lead to a parse failure (Failed to parse source [_na_]).
