### PR TITLE
Update to docs for SSL ca_file option

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -101,7 +101,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # SSL
   config :ssl, :validate => :boolean, :default => false
 
-  # SSL Certificate Authority file
+  # SSL Certificate Authority file in PEM encoded format, must also include any chain certificates as necessary 
   config :ca_file, :validate => :path
 
   def register


### PR DESCRIPTION
Make the expected file format and requirement for any chain certificates clearer.

Open to improvements on the wording of this doco text.