### PR TITLE
Fix scrolling requests by using json formatted bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.0.3
   - Docs: Add requirement to use version 4.0.2 or higher to support sending Content-Type headers
+  - Fix scrolling to use json bodies in the requests (this makes scrolling not work in ES 1.x)
 
 ## 4.0.2
   - Bump ES client to 5.0.2 to get content-type: json behavior

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -194,6 +194,6 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def scroll_request scroll_id
-    @client.scroll(:body => scroll_id, :scroll => @scroll)
+    @client.scroll(:body => { :scroll_id => scroll_id }, :scroll => @scroll)
   end
 end

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -63,7 +63,7 @@ describe LogStash::Inputs::Elasticsearch do
     client = Elasticsearch::Client.new
     expect(Elasticsearch::Client).to receive(:new).with(any_args).and_return(client)
     expect(client).to receive(:search).with(any_args).and_return(response)
-    expect(client).to receive(:scroll).with({ :body => "cXVlcnlUaGVuRmV0Y2g", :scroll=> "1m" }).and_return(scroll_reponse)
+    expect(client).to receive(:scroll).with({ :body => { :scroll_id => "cXVlcnlUaGVuRmV0Y2g" }, :scroll=> "1m" }).and_return(scroll_reponse)
 
     event = input(config) do |pipeline, queue|
       queue.pop
@@ -114,7 +114,7 @@ describe LogStash::Inputs::Elasticsearch do
     before do
       expect(Elasticsearch::Client).to receive(:new).with(any_args).and_return(client)
       expect(client).to receive(:search).with(any_args).and_return(response)
-      allow(client).to receive(:scroll).with({ :body => "cXVlcnlUaGVuRmV0Y2g", :scroll => "1m" }).and_return(scroll_reponse)
+      allow(client).to receive(:scroll).with({ :body => {:scroll_id => "cXVlcnlUaGVuRmV0Y2g"}, :scroll => "1m" }).and_return(scroll_reponse)
     end
 
     context 'when defining docinfo' do


### PR DESCRIPTION
This makes scrolling incompatible with ES 1.x
NOTE: It's already documented that version 5.x of elasticsearch-ruby gem isn't compatible with ES 1.x, so it should be ok to break scrolling here.

fixes https://github.com/logstash-plugins/logstash-input-elasticsearch/issues/62