### PR TITLE
fix on example code

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -78,7 +78,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   #       elasticsearch {
   #         hosts => "es.production.mysite.org"
   #         index => "mydata-2018.09.*"
-  #         query => "*"
+  #         
   #         size => 500
   #         scroll => "5m"
   #         docinfo => true


### PR DESCRIPTION
elk on 5.4.0 gives error if there is a "query => '*' "line

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
