### PR TITLE
Use the new_pipeline_from_string in devutils

### DIFF
--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -168,7 +168,7 @@ describe LogStash::Inputs::Elasticsearch do
             }
         ]
 
-        pipeline = LogStash::Pipeline.new(config_metadata_with_string)
+        pipeline = new_pipeline_from_string(config_metadata_with_string)
         queue = Queue.new
         pipeline.instance_eval do
           @output_func = lambda { |event| queue << event }


### PR DESCRIPTION
We have changed the method signature between 5.x and master, I have now
refactored the test to use the new new_pipeline_from_string helper
defined in devutils.