### PR TITLE
enable use of metadata fields in `add_field` decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+ - Enable use of docinfo (@metadata) fields in `add_field` decorations
+
 ## 4.0.6
   - Docs: Fix link syntax
 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -170,7 +170,6 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
   def push_hit(hit, output_queue)
     event = LogStash::Event.new(hit['_source'])
-    decorate(event)
 
     if @docinfo
       # do not assume event[@docinfo_target] to be in-place updatable. first get it, update it, then at the end set it in the event.
@@ -189,6 +188,8 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
       event.set(@docinfo_target, docinfo_target)
     end
+
+    decorate(event)
 
     output_queue << event
   end

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.0.6'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read from an Elasticsearch cluster, based on search query results"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -228,6 +228,27 @@ describe LogStash::Inputs::Elasticsearch do
         expect(event.get("[@metadata][_index]")).to eq('logstash-2014.10.12')
         expect(event.get("[@metadata][_id]")).to eq(nil)
       end
+
+      it 'should be able to reference metadata fields in `add_field` decorations' do
+        config = %q[
+          input {
+            elasticsearch {
+              hosts => ["localhost"]
+              query => '{ "query": { "match": { "city_name": "Okinawa" } }, "fields": ["message"] }'
+              docinfo => true
+              add_field => {
+                'identifier' => "foo:%{[@metadata][_type]}:%{[@metadata][_id]}"
+              }
+            }
+          }
+        ]
+
+        event = input(config) do |pipeline, queue|
+          queue.pop
+        end
+
+        expect(event.get('identifier')).to eq('foo:logs:C5b2xLQwTZa76jBmHIbwHQ')
+      end
     end
 
     context "when not defining the docinfo" do


### PR DESCRIPTION
By performing event decorations after the metadata field has been populated
we enable the supported `add_field` decoration to reference metadata fields.

Resolves logstash-plugins/logstash-input-elasticsearch#76