### PR TITLE
Scheduling support

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,6 +32,9 @@ plugin to version 4.0.2 or higher.
 
 Read from an Elasticsearch cluster, based on search query results.
 This is useful for replaying test logs, reindexing, etc.
+You can periodically schedule ingestion using a cron syntax 
+(see `schedule` setting) or run the query one time to load
+data into Logstash.
 
 Example:
 [source,ruby]
@@ -55,6 +58,25 @@ This would create an Elasticsearch query with the following format:
     }'
 
 
+==== Scheduling
+
+Input from this plugin can be scheduled to run periodically according to a specific
+schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
+The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
+
+Examples:
+
+|==========================================================
+| `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
+| `0 * * * *`                 | will execute on the 0th minute of every hour every day.
+| `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
+|==========================================================
+
+
+Further documentation describing this syntax can be found
+https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
+
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Input Configuration Options
 
@@ -71,6 +93,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-scroll>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
@@ -186,6 +209,18 @@ string authentication will be disabled.
 The query to be executed. Read the
 [Elasticsearch query DSL documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)
 for more information.
+
+[id="plugins-{type}s-{plugin}-schedule"]
+===== `schedule` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Schedule of when to periodically run statement, in Cron format
+for example: "* * * * *" (execute query every minute, on the minute)
+
+There is no schedule by default. If no schedule is given, then the statement is run
+exactly once.
 
 [id="plugins-{type}s-{plugin}-scroll"]
 ===== `scroll` 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -180,12 +180,12 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     if @schedule
       @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
       @scheduler.cron @schedule do
-        do_run(queue)
+        do_run(output_queue)
       end
 
       @scheduler.join
     else
-      do_run(queue)
+      do_run(output_queue)
     end
   end
 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -15,6 +15,8 @@ require "base64"
 # 
 # Read from an Elasticsearch cluster, based on search query results.
 # This is useful for replaying test logs, reindexing, etc.
+# It also supports periodically scheduling lookup enrichments
+# using a cron syntax (see `schedule` setting).
 #
 # Example:
 # [source,ruby]
@@ -36,6 +38,24 @@ require "base64"
 #       },
 #       "sort": [ "_doc" ]
 #     }'
+#
+# ==== Scheduling
+#
+# Input from this plugin can be scheduled to run periodically according to a specific
+# schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
+# The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
+#
+# Examples:
+#
+# |==========================================================
+# | `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
+# | `0 * * * *`                 | will execute on the 0th minute of every hour every day.
+# | `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
+# |==========================================================
+#
+#
+# Further documentation describing this syntax can be found https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
+#
 #
 class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   config_name "elasticsearch"
@@ -114,8 +134,16 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # SSL Certificate Authority file in PEM encoded format, must also include any chain certificates as necessary 
   config :ca_file, :validate => :path
 
+  # Schedule of when to periodically run statement, in Cron format
+  # for example: "* * * * *" (execute query every minute, on the minute)
+  #
+  # There is no schedule by default. If no schedule is given, then the statement is run
+  # exactly once.
+  config :schedule, :validate => :string
+
   def register
     require "elasticsearch"
+    require "rufus/scheduler"
 
     @options = {
       :index => @index,
@@ -147,7 +175,27 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     @client = Elasticsearch::Client.new(:hosts => hosts, :transport_options => transport_options)
   end
 
+
   def run(output_queue)
+    if @schedule
+      @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
+      @scheduler.cron @schedule do
+        do_run(queue)
+      end
+
+      @scheduler.join
+    else
+      do_run(queue)
+    end
+  end
+
+  def stop
+    @scheduler.stop if @scheduler
+  end
+
+  private
+
+  def do_run(output_queue)
     # get first wave of data
     r = @client.search(@options)
 
@@ -159,8 +207,6 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
       has_hits = r['has_hits']
     end
   end
-
-  private
 
   def process_next_scroll(output_queue, scroll_id)
     r = scroll_request(scroll_id)

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -25,6 +25,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'elasticsearch', ['>= 5.0.3', '< 6.0.0']
 
   s.add_runtime_dependency 'logstash-codec-json'
+  s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'sequel'
+  s.add_runtime_dependency 'tzinfo'
+  s.add_runtime_dependency 'tzinfo-data'
+  s.add_runtime_dependency 'rufus-scheduler'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'timecop'
 end

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -2,12 +2,23 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/elasticsearch"
 require "elasticsearch"
+require "timecop"
+require "stud/temporary"
+require "time"
+require "date"
 
 describe LogStash::Inputs::Elasticsearch do
 
+  let(:plugin) { LogStash::Inputs::Elasticsearch.new(config) }
+  let(:queue) { Queue.new }
+
   it_behaves_like "an interruptible input plugin" do
     let(:esclient) { double("elasticsearch-client") }
-    let(:config) { { } }
+    let(:config) do
+      {
+        "schedule" => "* * * * * UTC"
+      }
+    end
 
     before :each do
       allow(Elasticsearch::Client).to receive(:new).and_return(esclient)
@@ -250,4 +261,66 @@ describe LogStash::Inputs::Elasticsearch do
       end
     end
   end
+
+  context "when scheduling" do
+    let(:config) do
+      {
+        "hosts" => ["localhost"],
+        "query" => '{ "query": { "match": { "city_name": "Okinawa" } }, "fields": ["message"] }',
+        "schedule" => "* * * * * UTC"
+      }
+    end
+
+    response = {
+      "_scroll_id" => "cXVlcnlUaGVuRmV0Y2g",
+      "took" => 27,
+      "timed_out" => false,
+      "_shards" => {
+        "total" => 169,
+        "successful" => 169,
+        "failed" => 0
+      },
+      "hits" => {
+        "total" => 1,
+        "max_score" => 1.0,
+        "hits" => [ {
+          "_index" => "logstash-2014.10.12",
+          "_type" => "logs",
+          "_id" => "C5b2xLQwTZa76jBmHIbwHQ",
+          "_score" => 1.0,
+          "_source" => { "message" => ["ohayo"] }
+        } ]
+      }
+    }
+
+    scroll_reponse = {
+      "_scroll_id" => "r453Wc1jh0caLJhSDg",
+      "hits" => { "hits" => [] }
+    }
+
+    before do
+      plugin.register
+    end
+
+    it "should properly schedule" do
+
+      Timecop.travel(Time.new(2000))
+      Timecop.scale(60)
+      runner = Thread.new do
+        expect(plugin).to receive(:do_run) {
+          queue << LogStash::Event.new({})
+        }.at_least(:twice)
+
+        plugin.run(queue)
+      end
+      sleep 3
+      plugin.stop
+      runner.kill
+      runner.join
+      expect(queue.size).to eq(2)
+      Timecop.return
+    end
+
+  end
+
 end


### PR DESCRIPTION
Ported from _logstash-input-jdbc_ plugin the support for rufus based cron-like scheduling, i.e.
```
input {
  elasticsearch {
    hosts => [...]
    query => ...
    schedule => "*/10 * * * * * UTC"
  }
}
```