### PR TITLE
Adding support to return aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.0
+  - Add support to return either `hits` or `aggregations`
+
 ## 4.2.0
   - Docs: Deprecate `document_type`
   - Add support for scheduling periodic execution of the query #81

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -93,6 +93,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-response_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-scroll>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No
@@ -214,6 +215,15 @@ string authentication will be disabled.
 The query to be executed. Read the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
+
+[id="plugins-{type}s-{plugin}-response_type"]
+===== `response_type` 
+
+  * Value type is <<string,string>>
+  * Default value is `'hits'`
+  * Possible values are = `'hits'` or `'aggregations'`
+
+Allows you to specify which part of Elasticsearch's response to handle
 
 [id="plugins-{type}s-{plugin}-schedule"]
 ===== `schedule` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -93,7 +93,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-response_type>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-response_type>> |<<string,string>>, one of `["hits","aggregations"]`|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-scroll>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -216,13 +216,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
           has_hits = r['has_hits']
         end
       when 'aggregations'
-        aggs = r['aggregations']
-        event = LogStash::Event.new(aggs)
-
-        decorate(event)
-        output_queue << event
-      else
-        raise Exception.new("Unsupported response type: #{@response_type}")
+          push_aggregation(r, output_queue)
     end
 
   end
@@ -259,7 +253,13 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     output_queue << event
   end
 
-
+  def push_aggregation(response, output_queue)
+    aggs = response['aggregations']
+    event = LogStash::Event.new(aggs)
+    decorate(event)
+    output_queue << event
+  end
+  
   def scroll_request scroll_id
     @client.scroll(:body => { :scroll_id => scroll_id }, :scroll => @scroll)
   end

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -76,7 +76,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   config :query, :validate => :string, :default => '{ "sort": [ "_doc" ] }'
 
   # This allows you to speccify the response: either hits or aggregations
-  config :response_type, :validate => :string, :default => 'hits'
+  config :response_type, :validate => ['hits', 'aggregations'], :default => 'hits'
 
   # This allows you to set the maximum number of hits returned per scroll.
   config :size, :validate => :number, :default => 1000

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -75,6 +75,9 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
   config :query, :validate => :string, :default => '{ "sort": [ "_doc" ] }'
 
+  # This allows you to speccify the response: either hits or aggregations
+  config :response_type, :validate => :string, :default => 'hits'
+
   # This allows you to set the maximum number of hits returned per scroll.
   config :size, :validate => :number, :default => 1000
 
@@ -148,9 +151,14 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     @options = {
       :index => @index,
       :body => @query,
-      :scroll => @scroll,
-      :size => @size
+      :size => 0
     }
+
+    # Set scroll and size for hits
+    if @response_type == 'hits'
+      @options[:scroll] = @scroll
+      @options[:size] = @size
+    end
 
     transport_options = {}
 
@@ -198,14 +206,25 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   def do_run(output_queue)
     # get first wave of data
     r = @client.search(@options)
+    case @response_type
+      when 'hits'
+        r['hits']['hits'].each { |hit| push_hit(hit, output_queue) }
+        has_hits = r['hits']['hits'].any?
 
-    r['hits']['hits'].each { |hit| push_hit(hit, output_queue) }
-    has_hits = r['hits']['hits'].any?
+        while has_hits && !stop?
+          r = process_next_scroll(output_queue, r['_scroll_id'])
+          has_hits = r['has_hits']
+        end
+      when 'aggregations'
+        aggs = r['aggregations']
+        event = LogStash::Event.new(aggs)
 
-    while has_hits && !stop?
-      r = process_next_scroll(output_queue, r['_scroll_id'])
-      has_hits = r['has_hits']
+        decorate(event)
+        output_queue << event
+      else
+        raise Exception.new("Unsupported response type: #{@response_type}")
     end
+
   end
 
   def process_next_scroll(output_queue, scroll_id)
@@ -239,6 +258,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
     output_queue << event
   end
+
 
   def scroll_request scroll_id
     @client.scroll(:body => { :scroll_id => scroll_id }, :scroll => @scroll)

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -75,7 +75,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
   config :query, :validate => :string, :default => '{ "sort": [ "_doc" ] }'
 
-  # This allows you to speccify the response: either hits or aggregations
+  # This allows you to speccify the response type: either hits or aggregations
   config :response_type, :validate => ['hits', 'aggregations'], :default => 'hits'
 
   # This allows you to set the maximum number of hits returned per scroll.

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.2.0'
+  s.version         = '4.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -34,7 +34,7 @@ describe LogStash::Inputs::Elasticsearch do
     end
   end
 
-  it "should retrieve json event from elasticseach" do
+  it "should retrieve json event from elasticseach hits" do
     config = %q[
       input {
         elasticsearch {
@@ -83,7 +83,9 @@ describe LogStash::Inputs::Elasticsearch do
     insist { event }.is_a?(LogStash::Event)
     insist { event.get("message") } == [ "ohayo" ]
   end
+  it "should retrieve json event when specifying respones type" do
 
+  end
   context "with Elasticsearch document information" do
     let!(:response) do
       {
@@ -344,4 +346,59 @@ describe LogStash::Inputs::Elasticsearch do
 
   end
 
+  it "should retrieve json event from elasticsearch aggregations" do
+    config = %q{
+      input {
+        elasticsearch {
+          hosts => ["localhost"]
+          query => '{"aggs":{"cities":{"terms":{"field":"city_name"}}}}'
+          response_type => aggregations
+        }
+      }
+    }
+    response = {
+        "_scroll_id" => "cXVlcnlUaGVuRmV0Y2g",
+        "took" => 27,
+        "timed_out" => false,
+        "_shards" => {
+            "total" => 169,
+            "successful" => 169,
+            "failed" => 0
+        },
+        "hits" => {
+            "total" => 20,
+            "max_score" => 1.0,
+            "hits" => []
+        },
+        "aggregations" => {
+            "cities" => {
+                "doc_count_error_upper_bound" => 0,
+                "sum_other_doc_count"  => 0,
+                "buckets" => [
+                    {
+                        "key" => "Tirana",
+                        "doc_count" =>  10
+                    },
+                    {
+                        "key" => "Shkodra",
+                        "doc_count" =>  10
+                    }
+                ]
+            }
+        }
+    }
+    client = Elasticsearch::Client.new
+    expect(Elasticsearch::Client).to receive(:new).with(any_args).and_return(client)
+    expect(client).to receive(:search).with(any_args).and_return(response)
+    event = input(config) do |pipeline, queue|
+      queue.pop
+    end
+
+    insist { event }.is_a?(LogStash::Event)
+    expect(event.get("[cities][buckets]").map do |bucket| bucket["key"] end).to eq(['Tirana',"Shkodra"])
+  end
+
+  it "should fail for unsupported response type" do
+
+  end
 end

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -397,8 +397,4 @@ describe LogStash::Inputs::Elasticsearch do
     insist { event }.is_a?(LogStash::Event)
     expect(event.get("[cities][buckets]").map do |bucket| bucket["key"] end).to eq(['Tirana',"Shkodra"])
   end
-
-  it "should fail for unsupported response type" do
-
-  end
 end


### PR DESCRIPTION
Currently there's only support for getting hits from ElasticSearch's response. This is probably the most common use case, however, sometimes we might want to get the aggregations information.

This pull request is to add a new parameter _response_type_ which allows you to specify whether you need the hits, or aggregations and returns the relevant data.