### PR TITLE
make ssl verification mode configurable

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -99,6 +99,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-slices>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 |=======================================================================
 
@@ -112,6 +113,7 @@ input plugins.
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
+  * This option is ignored when <<plugins-{type}s-{plugin}-ssl>> is disabled.
 
 SSL Certificate Authority file in PEM encoded format, must also
 include any chain certificates as necessary.
@@ -283,6 +285,19 @@ instructions into the query.
 
 If enabled, SSL will be used when communicating with the Elasticsearch
 server (i.e. HTTPS will be used instead of plain HTTP).
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
+===== `ssl_certificate_verification`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+  * This option is ignored when <<plugins-{type}s-{plugin}-ssl>> is disabled.
+
+Disabling SSL verification is UNSAFE, and causes this input plugin to implicitly trust
+any server it connects to, including servers that present invalid, expired, forged, or
+self-signed certificates. When this setting is disabled, the connection between this
+input and the server that responds will be encrypted, but the identity of the server
+will not be validated.
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user` 


### PR DESCRIPTION
While disabling SSL Certificate Verification eliminates most of the benefits
of using TLS and should _rarely_ be used in production environments, doing so
is occasionally useful in debugging and testing.

This changeset ports the `ssl_certificate_verification` option that is
available in the Elasticsearch Output Plugin, including a similar warning
that is emitted to the plugin's logger.

It also adds specifications how the `ssl` and `ssl_certificate_verification`
directives propagate to the arguments used to create the client.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
