### PR TITLE
[documentation][issue/82] Add usage example of docinfo metadata in add_field

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -151,6 +151,19 @@ Example
       }
     }
 
+If set, it will be possible to use the metadata information in the <<plugins-{type}s-{plugin}-add_field>> common option.
+
+Example
+[source, ruby]
+    input {
+      elasticsearch {
+        docinfo => true
+        add_field => {
+          identifier => %{[@metadata][_index]}:%{[@metadata][_type]}:%{[@metadata][_id]}"
+        }
+      }
+    }
+
 
 NOTE: Starting with Logstash 6.0, the `document_type` option is
 deprecated due to the


### PR DESCRIPTION
This PR is trying to address the issue https://github.com/logstash-plugins/logstash-input-elasticsearch/issues/82

Documentation update to add usage example of docinfo metadata in add_field common option.

As the `add_field` is in the common options, I find it difficult to include the example of usage of the docinfo metadata in the associated section.

So I've choosen the `docinfo` section, where it was worth mentioning the metadata can be used only if `docinfo` is set.

I am totally open to change it if you have a better option.

The doc should also be applied to v4.1.0 (as this feature was added via https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/78).