### PR TITLE
bump to 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## Unreleased
-  - Add support for managed multi-slice scrolling with `slices` option.
+## 4.3.0
+  - Added managed slice scrolling with `slices` option
 
 ## 4.2.1
   - Docs: Set the default_codec doc attribute.

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.2.1'
+  s.version         = '4.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
```
% git lg v4.2.1..
* be3ea46 - (origin/master, master) [skip ci] Travis: update LOGSTASH_BRANCH from 6.[0..4] to 6.5 (4 weeks ago) <Rob Bavey>
* 762e540 - pin bundler version to < 2 (5 weeks ago) <Rob Bavey>
* 34308c0 - Merge pull request #94 from yaauie/managed-slices-option (5 months ago) <Ry Biesemeyer>
* 939f343 - add managed slice scrolling with `slices` option. (5 months ago) <Ry Biesemeyer>
```