### PR TITLE
Remove Hash#except from failing spec.

### DIFF
--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -125,7 +125,7 @@ describe LogStash::Inputs::Elasticsearch do
     end
 
     context 'without slices directive' do
-      let(:config) { super().except('slices') }
+      let(:config) { super.tap { |h| h.delete('slices') } }
       it 'runs just one slice' do
         expect(plugin).to receive(:do_run_slice).with(duck_type(:<<))
         expect(Thread).to_not receive(:new)


### PR DESCRIPTION
Remove use of Hash#except, which was previously brought in via the
 'i18n' gem, but, as of 7.0 no longer appears to be the case, and is
 causing test failures