### PR TITLE
retry search and scroll requests on failure

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -315,10 +315,28 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
   def scroll_request scroll_id
     client.scroll(:body => { :scroll_id => scroll_id }, :scroll => @scroll)
+  rescue => e
+    if stop?
+      @logger.error("Error performing scroll request to Elasticsearch", :error => e.class, :message => e.message)
+      raise e
+    else
+      @logger.error("Error performing scroll request to Elasticsearch. Retrying..", :error => e.class, :message => e.message)
+      sleep 1
+      retry
+    end
   end
 
   def search_request(options)
     client.search(options)
+  rescue => e
+    if stop?
+      @logger.error("Error performing search request to Elasticsearch", :error => e.class, :message => e.message)
+      raise e
+    else
+      @logger.error("Error performing search request to Elasticsearch. Retrying..", :error => e.class, :message => e.message)
+      sleep 1
+      retry
+    end
   end
 
   attr_reader :client


### PR DESCRIPTION
this prevents the input from restarting. in the case of sliced searches,
where threads are used, exceptions also cause logstash to fatally abort.

fixes #125 