### PR TITLE
Pass `ELASTIC_STACK_VERSION` env variable to docker image

### DIFF
--- a/.ci/docker-compose.override.yml
+++ b/.ci/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
     environment:
         - INTEGRATION=${INTEGRATION:-false}
         - SECURE_INTEGRATION=${SECURE_INTEGRATION:-false}
-
+        - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
   elasticsearch:
     build:
       context: ../


### PR DESCRIPTION
ELASTIC_STACK_VERSION was not being passed down to the docker image
causing the ESHelper.version_satisfies? helper method report the wrong
version, causing tests to fail due to doc types being incorrectly set.
