### PR TITLE
Doc:Update sliced scroll link to resolve to new location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.7.1
+  - [DOC] Updated sliced scroll link to resolve to correct location after doc structure change [#135](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/135)
+  - [DOC] Added usage example of docinfo metadata [#98](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/98)
+
 ## 4.7.0
   - Added api_key support [#131](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/131)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -184,7 +184,7 @@ Example
       }
     }
 
-If set, it will be possible to use the metadata information in the <<plugins-{type}s-{plugin}-add_field>> common option.
+If set, you can use metadata information in the <<plugins-{type}s-{plugin}-add_field>> common option.
 
 Example
 [source, ruby]
@@ -309,8 +309,8 @@ This allows you to set the maximum number of hits returned per scroll.
   * Sensible values range from 2 to about 8.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
-distinct slices of a query simultaneously using the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[Sliced Scroll API],
+distinct slices of a query simultaneously using
+https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#slice-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.7.0'
+  s.version         = '4.7.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Elasticsearch doc improvements and restructuring broke a link. This work fixes it. 
Minor edits.
