### PR TITLE
Fix concurrency bug that avoided to retrieve connection when using multiple slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.8.1
+  - Fixed connection error when using multiple `slices`. [#133](https://github.com/logstash-plugins/logstash-input-elasticsearch/issues/133)
+
 ## 4.8.0
   - Added the ability to configure connection-, request-, and socket-timeouts with `connect_timeout_seconds`, `request_timeout_seconds`, and `socket_timeout_seconds` [#121](https://github.com/logstash-plugins/logstash-input-elasticsearch/issues/121)
 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -4,6 +4,7 @@ require "logstash/namespace"
 require "logstash/json"
 require "logstash/util/safe_uri"
 require "base64"
+require_relative "patch"
 
 
 # .Compatibility Note

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.8.0'
+  s.version         = '4.8.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Patched the RoudRobin policy used by the underlying elasticsearch-transport gem.
In case of multiple slices there are one thread per slice and the library exposed a race condition while not protecting the access to the connections pool.

Fixes: #133
