### PR TITLE
Doc: Update links to logstash-to-cloud docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.8.3
+  - [DOC] Fixed links to restructured Logstash-to-cloud docs [#139](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/139)
+
 ## 4.8.2
   - [DOC] Document the permissions required in secured clusters [#137](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/137)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,7 +1,6 @@
 :plugin: elasticsearch
 :type: input
 :default_codec: json
-:branch: current
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -130,7 +129,7 @@ Authenticate using Elasticsearch API key. Note that this option also requires en
 
 Format is `id:api_key` where `id` and `api_key` are as returned by the
 Elasticsearch
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create
+https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create
 API key API].
 
 [id="plugins-{type}s-{plugin}-ca_file"]
@@ -150,7 +149,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
 For more info, check out the
-https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
 documentation]
 
 [id="plugins-{type}s-{plugin}-cloud_id"]
@@ -162,7 +161,7 @@ documentation]
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
 For more info, check out the
-https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
 documentation]
 
 [id="plugins-{type}s-{plugin}-connect_timeout_seconds"]
@@ -261,7 +260,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -293,7 +292,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="plugins-{type}s-{plugin}-request_timeout_seconds"]
@@ -345,7 +344,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using
-https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#slice-scroll[sliced scrolls],
+https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#slice-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 
@@ -393,5 +392,4 @@ empty string authentication will be disabled.
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:branch!:
 :default_codec!:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -145,7 +145,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -155,7 +155,7 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[Logstash-to-Cloud documentation]
+For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
 
 [id="plugins-{type}s-{plugin}-connect_timeout_seconds"]
 ===== `connect_timeout_seconds`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,7 @@
 :plugin: elasticsearch
 :type: input
 :default_codec: json
+:branch: current
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -127,7 +128,10 @@ input plugins.
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the `ssl` option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the Elasticsearch https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key API].
+Format is `id:api_key` where `id` and `api_key` are as returned by the
+Elasticsearch
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-create-api-key.html[Create
+API key API].
 
 [id="plugins-{type}s-{plugin}-ca_file"]
 ===== `ca_file` 
@@ -145,7 +149,9 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the
+https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+documentation]
 
 [id="plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -155,7 +161,9 @@ For more info, check out the https://www.elastic.co/guide/en/logstash/current/co
 
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
-For more info, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud documentation]
+For more info, check out the
+https://www.elastic.co/guide/en/logstash/{branch}/connecting-to-cloud.html[Logstash-to-Cloud
+documentation]
 
 [id="plugins-{type}s-{plugin}-connect_timeout_seconds"]
 ===== `connect_timeout_seconds`
@@ -253,7 +261,7 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Default value is `"logstash-*"`
 
 The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/multi-index.html[Multi Indices documentation]
 in the Elasticsearch documentation for more information on how to reference
 multiple indices.
 
@@ -285,7 +293,7 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
 The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html[Elasticsearch query DSL documentation]
 for more information.
 
 [id="plugins-{type}s-{plugin}-request_timeout_seconds"]
@@ -337,7 +345,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using
-https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#slice-scroll[sliced scrolls],
+https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#slice-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 
@@ -385,4 +393,5 @@ empty string authentication will be disabled.
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
+:branch!:
 :default_codec!:

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.8.2'
+  s.version         = '4.8.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
[Cloud rework](https://github.com/elastic/logstash/pull/11884) broke some links from the plugins. This PR updates the links and points one level up in docs to give user a bit more context for logstash->cloud.

Fixes: #138 