### PR TITLE
Introduce `target` option

### DIFF
--- a/.ci/docker-setup.sh
+++ b/.ci/docker-setup.sh
@@ -4,6 +4,42 @@
 # Ensure you have Docker installed locally and set the ELASTIC_STACK_VERSION environment variable.
 set -e
 
+
+download_and_load_docker_snapshot_artifact() {
+  project="${1?project name required}"
+
+  artifact_type="docker-image"
+  artifact_name_base="${project}${DISTRIBUTION_SUFFIX}-${ELASTIC_STACK_VERSION}-${artifact_type}"
+  echo "Downloading snapshot docker image: ${project}${DISTRIBUTION_SUFFIX} (${ELASTIC_STACK_VERSION})"
+
+  artifact_name_noarch="${artifact_name_base}.tar.gz"
+  artifact_name_arch="${artifact_name_base}-x86_64.tar.gz"
+
+  jq_extract_artifact_url=".build.projects.\"${project}\".packages | (.\"${artifact_name_noarch}\" // .\"${artifact_name_arch}\") | .url"
+
+  artifact_list=$(curl --silent "https://artifacts-api.elastic.co/v1/versions/${ELASTIC_STACK_VERSION}/builds/latest")
+  artifact_url=$(echo "${artifact_list}" | jq --raw-output "${jq_extract_artifact_url}")
+
+  if [[ "${artifact_url}" == "null" ]]; then
+    echo "Failed to find '${artifact_name_noarch}'"
+    echo "Failed to find '${artifact_name_arch}'"
+    echo "Listing:"
+    echo "${artifact_list}" | jq --raw-output ".build.projects.\"${project}\".packages | keys | map(select(contains(\"${artifact_type}\")))"
+    return 1
+  fi
+
+  echo "${artifact_url}"
+
+  cd /tmp
+  curl "${artifact_url}" > "${project}-docker-image.tar.gz"
+  tar xfvz "${project}-docker-image.tar.gz" repositories
+  echo "Loading ${project} docker image: "
+  cat repositories
+  docker load < "${project}-docker-image.tar.gz"
+  rm "${project}-docker-image.tar.gz"
+  cd -
+}
+
 VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/master/ci/logstash_releases.json"
 
 if [ "$ELASTIC_STACK_VERSION" ]; then
@@ -26,34 +62,9 @@ if [ "$ELASTIC_STACK_VERSION" ]; then
     echo "Testing against version: $ELASTIC_STACK_VERSION"
 
     if [[ "$ELASTIC_STACK_VERSION" = *"-SNAPSHOT" ]]; then
-        cd /tmp
-
-        jq=".build.projects.\"logstash\".packages.\"logstash-$ELASTIC_STACK_VERSION-docker-image.tar.gz\".url"
-        result=$(curl --silent https://artifacts-api.elastic.co/v1/versions/$ELASTIC_STACK_VERSION/builds/latest | jq -r $jq)
-        echo $result
-        curl $result > logstash-docker-image.tar.gz
-        tar xfvz logstash-docker-image.tar.gz  repositories
-        echo "Loading docker image: "
-        cat repositories
-        docker load < logstash-docker-image.tar.gz
-        rm logstash-docker-image.tar.gz
-        cd -
-
+        download_and_load_docker_snapshot_artifact "logstash"
         if [ "$INTEGRATION" == "true" ]; then
-
-          cd /tmp
-
-          jq=".build.projects.\"elasticsearch\".packages.\"elasticsearch-$ELASTIC_STACK_VERSION-docker-image.tar.gz\".url"
-          result=$(curl --silent https://artifacts-api.elastic.co/v1/versions/$ELASTIC_STACK_VERSION/builds/latest | jq -r $jq)
-          echo $result
-          curl $result > elasticsearch-docker-image.tar.gz
-          tar xfvz elasticsearch-docker-image.tar.gz  repositories
-          echo "Loading docker image: "
-          cat repositories
-          docker load < elasticsearch-docker-image.tar.gz
-          rm elasticsearch-docker-image.tar.gz
-          cd -
-
+            download_and_load_docker_snapshot_artifact "elasticsearch"
         fi
     fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.9.0
+  - Added `target` option, allowing the hit's source to target a specific field instead of being expanded at the root of the event. This allows the input to play nicer with the Elastic Common Schema when the input does not follow the schema. [#117](https://github.com/logstash-plugins/logstash-input-elasticsearch/issues/117)
+
 ## 4.8.3
   - [DOC] Fixed links to restructured Logstash-to-cloud docs [#139](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/139)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -111,6 +111,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-slices>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout_seconds>> | <<number,number>>|No
+| <<plugins-{type}s-{plugin}-target>> | https://www.elastic.co/guide/en/logstash/master/field-references-deepdive.html[field reference] | No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 |=======================================================================
 
@@ -376,6 +377,19 @@ server (i.e. HTTPS will be used instead of plain HTTP).
 
 The maximum amount of time, in seconds, to wait on an incomplete response from Elasticsearch while no additional data has been appended.
 Socket timeouts usually occur while waiting for the first byte of a response, such as when executing a particularly complex query.
+
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+* Value type is https://www.elastic.co/guide/en/logstash/master/field-references-deepdive.html[field reference]
+* There is no default value for this setting.
+
+Without a `target`, events are created from each hit's `_source` at the root level.
+When the `target` is set to a field reference, the `_source` of the hit is placed in the target field instead.
+
+This option can be useful to avoid populating unknown fields when a downstream schema such as ECS is enforced.
+It is also possible to target an entry in the event's metadata, which will be available during event processing but not exported to your outputs (e.g., `target \=> "[@metadata][_source]"`).
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user` 

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
+  s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'elasticsearch', '>= 5.0.3'


### PR DESCRIPTION
Adding a `target` option to the input allows users to specifically target where `_source` of a hit will be placed instead of polluting the top-level of the event.

Combined with the existing `docinfo_fields` and `docinfo_target`, this new setting can be used to ensure that _only_ known fields are populated at the root level, making it easier to define pipelines that are consistently compatible with a schema like ECS.