### PR TITLE
Doc: Replace cross doc links with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.9.1
+  - [DOC] Replaced hard-coded links with shared attributes [#143](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/143)
+  - [DOC] Added missing quote to docinfo_fields example [#145](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/145)
+
 ## 4.9.0
   - Added `target` option, allowing the hit's source to target a specific field instead of being expanded at the root of the event. This allows the input to play nicer with the Elastic Common Schema when the input does not follow the schema. [#117](https://github.com/logstash-plugins/logstash-input-elasticsearch/issues/117)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -111,7 +111,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-slices>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout_seconds>> | <<number,number>>|No
-| <<plugins-{type}s-{plugin}-target>> | https://www.elastic.co/guide/en/logstash/master/field-references-deepdive.html[field reference] | No
+| <<plugins-{type}s-{plugin}-target>> | {logstash-ref}/field-references-deepdive.html[field reference] | No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 |=======================================================================
 
@@ -378,7 +378,7 @@ Socket timeouts usually occur while waiting for the first byte of a response, su
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target`
 
-* Value type is https://www.elastic.co/guide/en/logstash/master/field-references-deepdive.html[field reference]
+* Value type is {logstash-ref}/field-references-deepdive.html[field reference]
 * There is no default value for this setting.
 
 Without a `target`, events are created from each hit's `_source` at the root level.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -129,7 +129,7 @@ Authenticate using Elasticsearch API key. Note that this option also requires en
 
 Format is `id:api_key` where `id` and `api_key` are as returned by the
 Elasticsearch
-https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create
+{ref}/security-api-create-api-key.html[Create
 API key API].
 
 [id="plugins-{type}s-{plugin}-ca_file"]
@@ -149,8 +149,7 @@ SSL Certificate Authority file in PEM encoded format, must also include any chai
 Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
 
 For more info, check out the
-https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
-documentation]
+{logstash-ref}/connecting-to-cloud.html[Logstash-to-Cloud documentation].
 
 [id="plugins-{type}s-{plugin}-cloud_id"]
 ===== `cloud_id`
@@ -161,8 +160,7 @@ documentation]
 Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
 For more info, check out the
-https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html[Logstash-to-Cloud
-documentation]
+{logstash-ref}/connecting-to-cloud.html[Logstash-to-Cloud documentation].
 
 [id="plugins-{type}s-{plugin}-connect_timeout_seconds"]
 ===== `connect_timeout_seconds`
@@ -259,10 +257,9 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Value type is <<string,string>>
   * Default value is `"logstash-*"`
 
-The index or alias to search. See
-https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html[Multi Indices documentation]
-in the Elasticsearch documentation for more information on how to reference
-multiple indices.
+The index or alias to search. See {ref}/multi-index.html[Multi Indices
+documentation] in the Elasticsearch documentation for more information on how to
+reference multiple indices.
 
 
 [id="plugins-{type}s-{plugin}-password"]
@@ -291,9 +288,8 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
   * Value type is <<string,string>>
   * Default value is `'{ "sort": [ "_doc" ] }'`
 
-The query to be executed. Read the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html[Elasticsearch query DSL documentation]
-for more information.
+The query to be executed. Read the {ref}/query-dsl.html[Elasticsearch query DSL
+documentation] for more information.
 
 [id="plugins-{type}s-{plugin}-request_timeout_seconds"]
 ===== `request_timeout_seconds`
@@ -344,7 +340,7 @@ This allows you to set the maximum number of hits returned per scroll.
 
 In some cases, it is possible to improve overall throughput by consuming multiple
 distinct slices of a query simultaneously using
-https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#slice-scroll[sliced scrolls],
+{ref}/paginate-search-results.html#slice-scroll[sliced scrolls],
 especially if the pipeline is spending significant time waiting on Elasticsearch
 to provide results.
 

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.9.0'
+  s.version         = '4.9.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Standardize links to other Elastic docs to use shared attributes
Bump to v.4.9.1