### PR TITLE
Doc: Add space-delimited URIs to hosts example

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -252,6 +252,21 @@ List of one or more Elasticsearch hosts to use for querying. Each host
 can be either IP, HOST, IP:port, or HOST:port. The port defaults to
 9200.
 
+**Examples**
+```
+Add examples here
+```
+
+{ls} 7.9 and later supports defining an environment variable `hosts =>
+'${ES_HOSTS}' with multiple whitespace delimited URIs. 
+This plugin automatically expands `hosts` strings that contain multiple
+white-space delimited URs into separate entries. 
+
+**Example**
+```
+ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"
+```
+
 [id="plugins-{type}s-{plugin}-index"]
 ===== `index` 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -252,20 +252,15 @@ List of one or more Elasticsearch hosts to use for querying. Each host
 can be either IP, HOST, IP:port, or HOST:port. The port defaults to
 9200.
 
-**Examples**
-```
-Add examples here
-```
+This option can accept an environment variable containing one or more hostnames separated by whitespace.
+Strings separated by whitespace are treated as separate entries.
 
-{ls} 7.9 and later supports defining an environment variable `hosts =>
-'${ES_HOSTS}' with multiple whitespace delimited URIs. 
-This plugin automatically expands `hosts` strings that contain multiple
-white-space delimited URs into separate entries. 
+*Examples:*
 
-**Example**
-```
-ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"
-```
+* `ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"`
+* `ES_HOSTS="127.0.0.1:9200 127.0.0.2:9200"`
+* `ES_HOSTS="http://127.0.0.1 http://127.0.0.2"`
+* `ES_HOSTS="https://127.0.0.1:9200/mypath https://127.0.0.2:9200/mypath"`
 
 [id="plugins-{type}s-{plugin}-index"]
 ===== `index` 

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -568,13 +568,13 @@ describe LogStash::Inputs::TestableElasticsearch do
       it "should set host(s)" do
         plugin.register
         client = plugin.send(:client)
-        expect( client.transport.hosts ).to eql [{
-                                                     :scheme => "https",
-                                                     :host => "ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io",
-                                                     :port => 9243,
-                                                     :path => "",
-                                                     :protocol => "https"
-                                                 }]
+        expect( client.transport.instance_variable_get(:@hosts) ).to eql [{
+                                                                              :scheme => "https",
+                                                                              :host => "ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io",
+                                                                              :port => 9243,
+                                                                              :path => "",
+                                                                              :protocol => "https"
+                                                                          }]
       end
 
       context 'invalid' do
@@ -600,7 +600,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       it "should set authorization" do
         plugin.register
         client = plugin.send(:client)
-        auth_header = client.transport.options[:transport_options][:headers][:Authorization]
+        auth_header = client.transport.instance_variable_get(:@options)[:transport_options][:headers][:Authorization]
 
         expect( auth_header ).to eql "Basic #{Base64.encode64('elastic:my-passwd-00').rstrip}"
       end
@@ -637,7 +637,7 @@ describe LogStash::Inputs::TestableElasticsearch do
         it "should set authorization" do
           plugin.register
           client = plugin.send(:client)
-          auth_header = client.transport.options[:transport_options][:headers][:Authorization]
+          auth_header = client.transport.instance_variable_get(:@options)[:transport_options][:headers][:Authorization]
 
           expect( auth_header ).to eql "ApiKey #{Base64.strict_encode64('foo:bar')}"
         end
@@ -658,7 +658,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       it "should set proxy" do
         plugin.register
         client = plugin.send(:client)
-        proxy = client.transport.options[:transport_options][:proxy]
+        proxy = client.transport.instance_variable_get(:@options)[:transport_options][:proxy]
 
         expect( proxy ).to eql "http://localhost:1234"
       end
@@ -670,7 +670,7 @@ describe LogStash::Inputs::TestableElasticsearch do
           plugin.register
           client = plugin.send(:client)
 
-          expect( client.transport.options[:transport_options] ).to_not include(:proxy)
+          expect( client.transport.instance_variable_get(:@options)[:transport_options] ).to_not include(:proxy)
         end
       end
     end

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -166,7 +166,7 @@ describe LogStash::Inputs::TestableElasticsearch do
     end
 
     context 'without slices directive' do
-      let(:config) { super.tap { |h| h.delete('slices') } }
+      let(:config) { super().tap { |h| h.delete('slices') } }
       it 'runs just one slice' do
         expect(plugin).to receive(:do_run_slice).with(duck_type(:<<))
         expect(Thread).to_not receive(:new)
@@ -563,7 +563,7 @@ describe LogStash::Inputs::TestableElasticsearch do
         'sample:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA=='
       end
 
-      let(:config) { super.merge({ 'cloud_id' => valid_cloud_id }) }
+      let(:config) { super().merge({ 'cloud_id' => valid_cloud_id }) }
 
       it "should set host(s)" do
         plugin.register
@@ -578,7 +578,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       end
 
       context 'invalid' do
-        let(:config) { super.merge({ 'cloud_id' => 'invalid:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlv' }) }
+        let(:config) { super().merge({ 'cloud_id' => 'invalid:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlv' }) }
 
         it "should fail" do
           expect { plugin.register }.to raise_error LogStash::ConfigurationError, /cloud_id.*? is invalid/
@@ -586,7 +586,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       end
 
       context 'hosts also set' do
-        let(:config) { super.merge({ 'cloud_id' => valid_cloud_id, 'hosts' => [ 'localhost:9200' ] }) }
+        let(:config) { super().merge({ 'cloud_id' => valid_cloud_id, 'hosts' => [ 'localhost:9200' ] }) }
 
         it "should fail" do
           expect { plugin.register }.to raise_error LogStash::ConfigurationError, /cloud_id and hosts/
@@ -595,7 +595,7 @@ describe LogStash::Inputs::TestableElasticsearch do
     end if LOGSTASH_VERSION > '6.0'
 
     describe "cloud.auth" do
-      let(:config) { super.merge({ 'cloud_auth' => LogStash::Util::Password.new('elastic:my-passwd-00') }) }
+      let(:config) { super().merge({ 'cloud_auth' => LogStash::Util::Password.new('elastic:my-passwd-00') }) }
 
       it "should set authorization" do
         plugin.register
@@ -606,7 +606,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       end
 
       context 'invalid' do
-        let(:config) { super.merge({ 'cloud_auth' => 'invalid-format' }) }
+        let(:config) { super().merge({ 'cloud_auth' => 'invalid-format' }) }
 
         it "should fail" do
           expect { plugin.register }.to raise_error LogStash::ConfigurationError, /cloud_auth.*? format/
@@ -614,7 +614,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       end
 
       context 'user also set' do
-        let(:config) { super.merge({ 'cloud_auth' => 'elastic:my-passwd-00', 'user' => 'another' }) }
+        let(:config) { super().merge({ 'cloud_auth' => 'elastic:my-passwd-00', 'user' => 'another' }) }
 
         it "should fail" do
           expect { plugin.register }.to raise_error LogStash::ConfigurationError, /Multiple authentication options are specified/
@@ -624,7 +624,7 @@ describe LogStash::Inputs::TestableElasticsearch do
 
     describe "api_key" do
       context "without ssl" do
-        let(:config) { super.merge({ 'api_key' => LogStash::Util::Password.new('foo:bar') }) }
+        let(:config) { super().merge({ 'api_key' => LogStash::Util::Password.new('foo:bar') }) }
 
         it "should fail" do
           expect { plugin.register }.to raise_error LogStash::ConfigurationError, /api_key authentication requires SSL\/TLS/
@@ -632,7 +632,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       end
 
       context "with ssl" do
-        let(:config) { super.merge({ 'api_key' => LogStash::Util::Password.new('foo:bar'), "ssl" => true }) }
+        let(:config) { super().merge({ 'api_key' => LogStash::Util::Password.new('foo:bar'), "ssl" => true }) }
 
         it "should set authorization" do
           plugin.register
@@ -643,7 +643,7 @@ describe LogStash::Inputs::TestableElasticsearch do
         end
 
         context 'user also set' do
-          let(:config) { super.merge({ 'api_key' => 'foo:bar', 'user' => 'another' }) }
+          let(:config) { super().merge({ 'api_key' => 'foo:bar', 'user' => 'another' }) }
 
           it "should fail" do
             expect { plugin.register }.to raise_error LogStash::ConfigurationError, /Multiple authentication options are specified/
@@ -653,7 +653,7 @@ describe LogStash::Inputs::TestableElasticsearch do
     end if LOGSTASH_VERSION > '6.0'
 
     describe "proxy" do
-      let(:config) { super.merge({ 'proxy' => 'http://localhost:1234' }) }
+      let(:config) { super().merge({ 'proxy' => 'http://localhost:1234' }) }
 
       it "should set proxy" do
         plugin.register
@@ -664,7 +664,7 @@ describe LogStash::Inputs::TestableElasticsearch do
       end
 
       context 'invalid' do
-        let(:config) { super.merge({ 'proxy' => '${A_MISSING_ENV_VAR:}' }) }
+        let(:config) { super().merge({ 'proxy' => '${A_MISSING_ENV_VAR:}' }) }
 
         it "should not set proxy" do
           plugin.register

--- a/spec/inputs/integration/elasticsearch_spec.rb
+++ b/spec/inputs/integration/elasticsearch_spec.rb
@@ -51,7 +51,7 @@ describe LogStash::Inputs::Elasticsearch do
     let(:password) { 'abc123' }
     let(:ca_file) { "spec/fixtures/test_certs/test.crt" }
     let(:client_options) {{:ca_file => ca_file, :user => user, :password => password}}
-    let(:config)   { super.merge({
+    let(:config)   { super().merge({
                        'user' => user,
                        'password' => password,
                        'ssl' => true,


### PR DESCRIPTION
Improve documentation by adding meaningful examples
