### PR TITLE
Fixed SSL handshake hang indefinitely with proxy setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.9.3
-  - Fixed SSL handshake hang indefinitely with proxy setup
+  - Fixed SSL handshake hang indefinitely with proxy setup [#156](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/156)
 
 ## 4.9.2
   - Fix: a regression (in LS 7.14.0) where due the elasticsearch client update (from 5.0.5 to 7.5.0) the `Authorization` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.9.3
+  - Fixed SSL handshake hang indefinitely with proxy setup
+
 ## 4.9.2
   - Fix: a regression (in LS 7.14.0) where due the elasticsearch client update (from 5.0.5 to 7.5.0) the `Authorization` 
     header isn't passed, this leads to the plugin not being able to leverage `user`/`password` credentials set by the user.

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.9.2'
+  s.version         = '4.9.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'tzinfo'
   s.add_runtime_dependency 'tzinfo-data'
   s.add_runtime_dependency 'rufus-scheduler'
-  s.add_runtime_dependency 'manticore', "~> 0.6"
+  s.add_runtime_dependency 'manticore', ">= 0.7.1"
   s.add_development_dependency 'faraday', "~> 0.15.4"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
the fix in upstream has merged and [released](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1032#issuecomment-900782420) in 0.7.1 gem
Hence, update manticore

Fix: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1033
Related: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1032