### PR TITLE
Fix too_long_frame_excepton by passing scroll_id in the body

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -347,7 +347,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def clear_scroll(scroll_id)
-    @client.clear_scroll(scroll_id: scroll_id) if scroll_id
+    @client.clear_scroll(:body => { :scroll_id => scroll_id }) if scroll_id
   rescue => e
     # ignore & log any clear_scroll errors
     logger.warn("Ignoring clear_scroll exception", message: e.message, exception: e.class)


### PR DESCRIPTION
This fixes #141.
