### PR TITLE
Doc: Update to docs for SSL ca_file option

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -150,7 +150,7 @@ API key API].
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-SSL Certificate Authority file in PEM encoded format, must also include any chain certificates as necessary.
+SSL Certificate Authority file in PEM encoded format, must also include any chain certificates as necessary. This setting is ignored unless `ssl` is set to true.
 
 [id="plugins-{type}s-{plugin}-cloud_auth"]
 ===== `cloud_auth`


### PR DESCRIPTION
`ca_file` setting is ignored unless `ssl` is set to true.