### PR TITLE
Test: less double leaking failures (on CI)

### DIFF
--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -740,9 +740,7 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
             begin
               @server = WEBrick::HTTPServer.new :Port => 0, :DocumentRoot => ".",
                        :Logger => Cabin::Channel.get, # silence WEBrick logging
-                       :StartCallback => Proc.new {
-                             queue.push("started")
-                           }
+                       :StartCallback => Proc.new { queue.push("started") }
               @port = @server.config[:Port]
               @server.mount_proc '/' do |req, res|
                 res.body = '''
@@ -811,11 +809,9 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
                 @first_req_waiter.countDown()
               end
 
-
-
               @server.start
             rescue => e
-              puts "Error in webserver thread #{e}"
+              warn "ERROR in webserver thread #{e.inspect}\n  #{e.backtrace.join("\n  ")}"
               # ignore
             end
           end

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -910,6 +910,8 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
 
           plugin.register
         end
+
+        after { plugin.do_stop }
       end
     end
 

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -885,13 +885,16 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
     end
 
     it "should properly schedule" do
-      expect(plugin).to receive(:do_run) {
-        queue << LogStash::Event.new({})
-      }.at_least(:twice)
-      runner = Thread.start { plugin.run(queue) }
-      sleep 3.0
-      plugin.stop
-      runner.join
+      begin
+        expect(plugin).to receive(:do_run) {
+          queue << LogStash::Event.new({})
+        }.at_least(:twice)
+        runner = Thread.start { plugin.run(queue) }
+        sleep 3.0
+      ensure
+        plugin.do_stop
+        runner.join if runner
+      end
       expect(queue.size).to be >= 2
     end
 

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -123,7 +123,8 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
     end
 
     before(:each) do
-      expect(Elasticsearch::Client).to receive(:new).with(any_args).and_return client = Elasticsearch::Client.new
+      client = Elasticsearch::Client.new
+      expect(Elasticsearch::Client).to receive(:new).with(any_args).and_return(client)
       expect(client).to receive(:search).with(any_args).and_return(mock_response)
       expect(client).to receive(:scroll).with({ :body => { :scroll_id => "cXVlcnlUaGVuRmV0Y2g" }, :scroll=> "1m" }).and_return(mock_scroll_response)
       expect(client).to receive(:clear_scroll).and_return(nil)


### PR DESCRIPTION
Refactoring of test code, avoiding the "old" `input(config) do |pipeline, queue| ...` format.

motivated mostly due (still - https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/169) running into:
```
logstash_1_c3816da54f91 |      Failure/Error: @client.search(options)
logstash_1_c3816da54f91 |        #<Double "elasticsearch-client"> was originally created in one example but has leaked into another example and can no longer be used. rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
logstash_1_c3816da54f91 |      # ./lib/logstash/inputs/elasticsearch.rb:361:in `search_request'
logstash_1_c3816da54f91 |      # ./lib/logstash/inputs/elasticsearch.rb:290:in `do_run_slice'
logstash_1_c3816da54f91 |      # ./lib/logstash/inputs/elasticsearch.rb:269:in `do_run'
logstash_1_c3816da54f91 |      # ./lib/logstash/inputs/elasticsearch.rb:252:in `block in run'
logstash_1_c3816da54f91 | 
logstash_1_c3816da54f91 | Finished in 1 minute 4.32 seconds (files took 10.89 seconds to load)
logstash_1_c3816da54f91 | 69 examples, 2 failures

logstash_1_c3816da54f91 | 
logstash_1_c3816da54f91 | Failed examples:
logstash_1_c3816da54f91 | 
logstash_1_c3816da54f91 | rspec ./spec/inputs/elasticsearch_spec.rb:49 # LogStash::Inputs::Elasticsearch behaves like an interruptible input plugin #stop returns from run

logstash_1_c3816da54f91 | rspec './spec/inputs/elasticsearch_spec.rb[1:3:2:1]' # LogStash::Inputs::Elasticsearch `ecs_compatibility => disabled` when a target is set creates the event using the target
```