### PR TITLE
add retry for query

### DIFF
--- a/lib/logstash/helpers/loggable_try.rb
+++ b/lib/logstash/helpers/loggable_try.rb
@@ -1,0 +1,18 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+require 'stud/try'
+
+module LogStash module Helpers
+  class LoggableTry < Stud::Try
+    def initialize(logger, name)
+      @logger = logger
+      @name = name
+    end
+
+    def log_failure(exception, fail_count, message)
+      @logger.warn("Attempt to #{@name} but failed. #{message}", fail_count: fail_count, exception: exception.message)
+    end
+  end
+end end


### PR DESCRIPTION
Prior to this change, throwing exceptions in [search_request() ](https://github.com/logstash-plugins/logstash-input-elasticsearch/blob/657c3ff1b3b6326106b82ce8ca8decb618fa59cd/lib/logstash/inputs/elasticsearch.rb#L361)crashes Logstash as it is [unable to be caught](https://github.com/elastic/logstash/issues/11603) in the [inputworker()](https://github.com/elastic/logstash/blob/v8.3.3/logstash-core/lib/logstash/java_pipeline.rb#L405). Hence, this commit adds retry for error handling for query. 

Add `tries` option for the number of runs 
- should be >= 1
- 2 means having 1 execution and 1 retry

Use Stud::Try for retry in Thread. After retries fail, log an error msg.

