### PR TITLE
An option to control SSL certificate validation added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.16.0
-  - Added `ssl_certificate_verification` option to control SSL certificate verification [#N](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/N)
+  - Added `ssl_certificate_verification` option to control SSL certificate verification [#180](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/180)
 
 ## 4.15.0
   - Feat: add `retries` option. allow retry for failing query [#179](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.16.0
+  - Added `ssl_certificate_verification` option to control SSL certificate verification [#N](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/N)
+
 ## 4.15.0
   - Feat: add `retries` option. allow retry for failing query [#179](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/179)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -122,6 +122,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-slices>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout_seconds>> | <<number,number>>|No
 | <<plugins-{type}s-{plugin}-target>> | {logstash-ref}/field-references-deepdive.html[field reference] | No
 | <<plugins-{type}s-{plugin}-retries>> | <<number,number>>|No
@@ -413,6 +414,16 @@ instructions into the query.
 
 If enabled, SSL will be used when communicating with the Elasticsearch
 server (i.e. HTTPS will be used instead of plain HTTP).
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
+===== `ssl_certificate_verification`
+
+* Value type is <<boolean,boolean>>
+* Default value is `true`
+
+Option to validate the server's certificate. Disabling this severely compromises security.
+For more information on disabling certificate verification please read
+https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
 
 [id="plugins-{type}s-{plugin}-socket_timeout_seconds"]
 ===== `socket_timeout_seconds`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -422,12 +422,12 @@ server (i.e. HTTPS will be used instead of plain HTTP).
 * Default value is `true`
 
 Option to validate the server's certificate. Disabling this severely compromises security.
-When certificate validation is disabled this plugin implicitly trusts the machine
-resolved at the given address without validating its proof-of-identity, which can
-lead to this plugin transmitting credentials to or processing data from an untrustworthy
+When certificate validation is disabled, this plugin implicitly trusts the machine
+resolved at the given address without validating its proof-of-identity.
+In this scenario, the plugin can transmit credentials to or process data from an untrustworthy
 man-in-the-middle or other compromised infrastructure.
-For more information on disabling certificate verification please read
-https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+More information on the importance of certificate verification:
+**https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf**.
 
 [id="plugins-{type}s-{plugin}-socket_timeout_seconds"]
 ===== `socket_timeout_seconds`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -422,6 +422,10 @@ server (i.e. HTTPS will be used instead of plain HTTP).
 * Default value is `true`
 
 Option to validate the server's certificate. Disabling this severely compromises security.
+When certificate validation is disabled this plugin implicitly trusts the machine
+resolved at the given address without validating its proof-of-identity, which can
+lead to this plugin transmitting credentials to or processing data from an untrustworthy
+man-in-the-middle or other compromised infrastructure.
 For more information on disabling certificate verification please read
 https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -190,6 +190,11 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # SSL Certificate Authority file in PEM encoded format, must also include any chain certificates as necessary 
   config :ca_file, :validate => :path
 
+  # Option to validate the server's certificate. Disabling this severely compromises security.
+  # For more information on disabling certificate verification please read
+  # https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+  config :ssl_certificate_verification, :validate => :boolean, :default => true
+
   # Schedule of when to periodically run statement, in Cron format
   # for example: "* * * * *" (execute query every minute, on the minute)
   #
@@ -432,6 +437,11 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     ssl_options[:ssl] = true if @ssl
     ssl_options[:ca_file] = @ca_file if @ssl && @ca_file
     ssl_options[:trust_strategy] = trust_strategy_for_ca_trusted_fingerprint
+    if @ssl && !@ssl_certificate_verification
+      logger.warn "You have enabled encryption but DISABLED certificate verification, " +
+                    "to make sure your data is secure remove `ssl_certificate_verification => false`"
+      ssl_options[:verify] = :disable
+    end
 
     ssl_options
   end

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -191,7 +191,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   config :ca_file, :validate => :path
 
   # Option to validate the server's certificate. Disabling this severely compromises security.
-  # For more information on disabling certificate verification please read
+  # For more information on the importance of certificate verification please read
   # https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
   config :ssl_certificate_verification, :validate => :boolean, :default => true
 

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -698,6 +698,14 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
             expect { plugin.register }.to raise_error LogStash::ConfigurationError, /Multiple authentication options are specified/
           end
         end
+        
+        context 'ssl verification disabled' do
+          let(:config) { super().merge({ 'ssl_certificate_verification' => false }) }
+          it 'should warn data security risk' do
+            expect(plugin.logger).to receive(:warn).once.with("You have enabled encryption but DISABLED certificate verification, to make sure your data is secure remove `ssl_certificate_verification => false`")
+            plugin.register
+          end
+        end
       end
     end if LOGSTASH_VERSION > '6.0'
 


### PR DESCRIPTION
### What this PR does?
As per customers request, this PR intends to add an option to control SSL certificate validation.

Closes #33 

### Tests
#### Unit tests
```
# command
$rspec spec/inputs/elasticsearch_spec.rb:702

# result
Finished in 0.63507 seconds (files took 2.33 seconds to load)
1 example, 0 failures
```

### Manual testing
1. Use following configuration, make sure to set ES endpoint, user name and password
```
input {
    elasticsearch {
        # ... elasticsearch host, user name & password settings
        index => "ssl-certificate-validation-test"
        query => '{ "query": { "match": { "host.hostname": "mashhur-local" } } }'
        ssl => true
        ssl_certificate_verification => false
    }
}
output { stdout {}}
```
2. Run Logstash and check if it is giving a `WARN` about data security risk
```
# command
bin/logstash -f config/ssl-disabled.conf

# result
[2022-08-10T09:35:08,662][WARN ][logstash.inputs.elasticsearch][main] You have enabled encryption but DISABLED certificate verification, to make sure your data is secure remove `ssl_certificate_verification => false`
```
