### PR TITLE
Add support to search after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.19.0
-  - TODO
+  - Added `search_api` option to support `search_after` and `scroll` [#198](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/198)
+    - The default value `auto` uses `search_after` for Elasticsearch >= 8, otherwise, fall back to `scroll` 
 
 ## 4.18.0
   - Added request header `Elastic-Api-Version` for serverless [#195](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/195)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.19.0
+  - TODO
+
 ## 4.18.0
   - Added request header `Elastic-Api-Version` for serverless [#195](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/195)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -390,7 +390,7 @@ round trip (i.e. between the previous scroll request, to the next).
 `auto` uses `search_after` for Elasticsearch version `8.0.0` or higher, otherwise, fall back to `scroll` API.
 
 `search_after` uses {ref}/point-in-time-api.html#point-in-time-api[point in time] and sort value to search.
-The query requires to have at least one `sort` field. Check out <<plugins-{type}s-{plugin}-query>>.
+The query requires at least one `sort` field, as described in the <<plugins-{type}s-{plugin}-query>> parameter.
 
 `scroll` uses {ref}/paginate-search-results.html#scroll-search-results[scroll] API to search, which is no longer recommended.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -387,7 +387,7 @@ round trip (i.e. between the previous scroll request, to the next).
 * Value can be any of: `auto`, `search_after`, `scroll`
 * Default value is `auto`
 
-With `auto` the plugin uses the `search_after` parameter for Elasticsearch version `8.0.0` or higher, otherwise, the `scroll` API is used instead.
+With `auto` the plugin uses the `search_after` parameter for Elasticsearch version `8.0.0` or higher, otherwise the `scroll` API is used instead.
 
 `search_after` uses {ref}/point-in-time-api.html#point-in-time-api[point in time] and sort value to search.
 The query requires at least one `sort` field, as described in the <<plugins-{type}s-{plugin}-query>> parameter.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -335,7 +335,7 @@ The query to be executed. Read the {ref}/query-dsl.html[Elasticsearch query DSL
 documentation] for more information.
 
 When <<plugins-{type}s-{plugin}-search_api>> resolves to `search_after` and the query does not specify `sort`,
-the default sort `'{ "sort": { "_shard_doc": "asc" } }'` will be added to the query. Check out {ref}/paginate-search-results.html#search-after[Elasticsearch search after]
+the default sort `'{ "sort": { "_shard_doc": "asc" } }'` will be added to the query. Please refer to the {ref}/paginate-search-results.html#search-after[Elasticsearch search_after] parameter to know more.
 
 [id="plugins-{type}s-{plugin}-request_timeout_seconds"]
 ===== `request_timeout_seconds`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -118,6 +118,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-request_timeout_seconds>> | <<number,number>>|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-scroll>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-search_api>> |<<string,string>>, one of `["auto", "search_after", "scroll"]`|No
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-slices>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
@@ -333,6 +334,9 @@ environment variables e.g. `proxy => '${LS_PROXY:}'`.
 The query to be executed. Read the {ref}/query-dsl.html[Elasticsearch query DSL
 documentation] for more information.
 
+When <<plugins-{type}s-{plugin}-search_api>> resolves to `search_after` and the query does not specify `sort`,
+the default sort `'{ "sort": { "_shard_doc": "asc" } }'` will be added to the query. Check out {ref}/paginate-search-results.html#search-after[Elasticsearch search after]
+
 [id="plugins-{type}s-{plugin}-request_timeout_seconds"]
 ===== `request_timeout_seconds`
 
@@ -376,6 +380,19 @@ exactly once.
 This parameter controls the keepalive time in seconds of the scrolling
 request and initiates the scrolling process. The timeout applies per
 round trip (i.e. between the previous scroll request, to the next).
+
+[id="plugins-{type}s-{plugin}-seearch_api"]
+===== `search_api`
+
+* Value can be any of: `auto`, `search_after`, `scroll`
+* Default value is `auto`
+
+`auto` uses `search_after` for Elasticsearch version `8.0.0` or higher, otherwise, fall back to `scroll` API.
+
+`search_after` uses {ref}/point-in-time-api.html#point-in-time-api[point in time] and sort value to search.
+The query requires to have at least one `sort` field. Check out <<plugins-{type}s-{plugin}-query>>.
+
+`scroll` uses {ref}/paginate-search-results.html#scroll-search-results[scroll] API to search, which is no longer recommended.
 
 [id="plugins-{type}s-{plugin}-size"]
 ===== `size` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -387,7 +387,7 @@ round trip (i.e. between the previous scroll request, to the next).
 * Value can be any of: `auto`, `search_after`, `scroll`
 * Default value is `auto`
 
-`auto` uses `search_after` for Elasticsearch version `8.0.0` or higher, otherwise, fall back to `scroll` API.
+With `auto` the plugin uses the `search_after` parameter for Elasticsearch version `8.0.0` or higher, otherwise, the `scroll` API is used instead.
 
 `search_after` uses {ref}/point-in-time-api.html#point-in-time-api[point in time] and sort value to search.
 The query requires at least one `sort` field, as described in the <<plugins-{type}s-{plugin}-query>> parameter.

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -107,7 +107,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # The number of retries to run the query. If the query fails after all retries, it logs an error message.
   config :retries, :validate => :number, :default => 0
 
-  # Default auto will use search_after api for Elasticsearch 8 and use scroll api for 7
+  # Default `auto` will use `search_after` api for Elasticsearch 8 and use `scroll` api for 7
   # Set to scroll to fallback to previous version
   config :search_api, :validate => %w[auto search_after scroll], :default => "auto"
 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -637,7 +637,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
                                    else
                                      "scroll"
                                    end
-                             logger.info("`search_api => auto` resolved to `#{api}`, :elasticsearch => es_version)
+                             logger.info("`search_api => auto` resolved to `#{api}`", :elasticsearch => es_version)
                              api
                            else
                              @search_api

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -632,20 +632,23 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
   def setup_search_api
     @resolved_search_api = if @search_api == "auto"
-                             if es_major_version >= 8
-                               "search_after"
-                             else
-                               "scroll"
-                             end
+                             api = if es_major_version >= 8
+                                    "search_after"
+                                   else
+                                     "scroll"
+                                   end
+                             logger.info("`search_api => auto` resolved to `#{api}` since we are connected to Elasticsearch #{es_version}")
+                             api
                            else
                              @search_api
                            end
 
-    if @resolved_search_api == "search_after"
-      @paginated_search = LogStash::Inputs::Elasticsearch::SearchAfter.new(@client, self)
-    else
-      @paginated_search = LogStash::Inputs::Elasticsearch::Scroll.new(@client, self)
-    end
+
+    @paginated_search = if @resolved_search_api == "search_after"
+                          LogStash::Inputs::Elasticsearch::SearchAfter.new(@client, self)
+                        else
+                          LogStash::Inputs::Elasticsearch::Scroll.new(@client, self)
+                        end
   end
 
   module URIOrEmptyValidator

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -647,6 +647,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     @paginated_search = if @resolved_search_api == "search_after"
                           LogStash::Inputs::Elasticsearch::SearchAfter.new(@client, self)
                         else
+                          logger.warn("scroll API is no longer recommended for pagination. Consider using search_after instead.") if es_major_version >= 8
                           LogStash::Inputs::Elasticsearch::Scroll.new(@client, self)
                         end
   end

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -637,7 +637,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
                                    else
                                      "scroll"
                                    end
-                             logger.info("`search_api => auto` resolved to `#{api}` since we are connected to Elasticsearch #{es_version}")
+                             logger.info("`search_api => auto` resolved to `#{api}`, :elasticsearch => es_version)
                              api
                            else
                              @search_api

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -22,19 +22,11 @@ module LogStash
           @pipeline_id = plugin.pipeline_id
         end
 
-        JOB_NAME = "run query"
         def do_run(output_queue)
           # if configured to run a single slice, don't bother spinning up threads
           return retryable_search(output_queue) if @slices.nil? || @slices <= 1
 
-          slice_search(output_queue)
-        end
-
-        def retryable_search(output_queue, slice_id=nil)
-          retryable(JOB_NAME) do
-            r = search(output_queue, slice_id)
-            r
-          end
+          retryable_slice_search(output_queue)
         end
 
         def retryable(job_name, &block)
@@ -48,16 +40,18 @@ module LogStash
           end
         end
 
-        def search(output_queue, slice_id=nil)
+        def retryable_search(output_queue)
           raise NotImplementedError
         end
 
-        def slice_search(output_queue)
+        def retryable_slice_search(output_queue)
           raise NotImplementedError
         end
       end
 
       class Scroll < PaginatedSearch
+        SCROLL_JOB = "run scroll"
+
         def search_options(slice_id)
           query = @query
           query = @query.merge('slice' => { 'id' => slice_id, 'max' => @slices}) unless slice_id.nil?
@@ -103,7 +97,13 @@ module LogStash
           end
         end
 
-        def slice_search(output_queue)
+        def retryable_search(output_queue, slice_id=nil)
+          retryable(SCROLL_JOB) do
+            search(output_queue, slice_id)
+          end
+        end
+
+        def retryable_slice_search(output_queue)
           logger.warn("managed slices for query is very large (#{@slices}); consider reducing") if @slices > 8
 
           @slices.times.map do |slice_id|
@@ -125,7 +125,98 @@ module LogStash
       end
 
       class SearchAfter < PaginatedSearch
+        PIT_JOB = "create point in time"
+        SEARCH_AFTER_JOB = "run search after"
 
+        def create_pit
+          logger.debug("create point in time")
+          r = @client.open_point_in_time(index: @index, keep_alive: @scroll)
+          r['id']
+        end
+
+        def search_options(pit_id: , search_after: nil, slice_id: nil)
+          body = @query.merge({
+                                :pit => {
+                                  :id => pit_id,
+                                  :keep_alive => @scroll
+                                }
+                              })
+          body = body.merge(:search_after => search_after) unless search_after.nil?
+          body = body.merge(:slice => {:id => slice_id, :max => @slices}) unless slice_id.nil?
+          {
+            :size => @size,
+            :body => body
+          }
+        end
+
+        def next_page(pit_id: , search_after: nil, slice_id: nil)
+          options = search_options(pit_id: pit_id, search_after: search_after, slice_id: slice_id)
+          @client.search(options)
+        end
+
+        def process_page(output_queue)
+          r = yield
+          r['hits']['hits'].each { |hit| @plugin.push_hit(hit, output_queue) }
+          search_after = r['hits']['hits'][-1]['sort'] rescue nil
+          [ r['hits']['hits'].any?, search_after ]
+        end
+
+        def with_pit
+          begin
+            pit_id = retryable(PIT_JOB) { create_pit }
+            yield pit_id if pit_id.is_a?(String)
+          ensure
+            clear(pit_id)
+          end
+        end
+
+        def search(output_queue:, slice_id: nil, pit_id:)
+          log_hash = {}
+          log_hash = log_hash.merge({ slice_id: slice_id, slices: @slices }) unless slice_id.nil?
+          logger.info("Query start", log_hash)
+
+          has_hits = true
+          search_after = nil
+
+          while has_hits && !@plugin.stop?
+            logger.debug("Query progress", log_hash)
+            has_hits, search_after = process_page(output_queue) do
+              next_page(pit_id: pit_id, search_after: search_after, slice_id: slice_id)
+            end
+          end
+
+          logger.info("Query completed", log_hash)
+        end
+
+        def retryable_search(output_queue)
+          with_pit do |pit_id|
+            retryable(SEARCH_AFTER_JOB) do
+              search(output_queue: output_queue, pit_id: pit_id)
+            end
+          end
+        end
+
+        def retryable_slice_search(output_queue)
+          with_pit do |pit_id|
+            @slices.times.map do |slice_id|
+              Thread.new do
+                LogStash::Util::set_thread_name("[#{@pipeline_id}]|input|elasticsearch|slice_#{slice_id}")
+                retryable(SEARCH_AFTER_JOB) do
+                  search(output_queue: output_queue, slice_id: slice_id, pit_id: pit_id)
+                end
+              end
+            end.map(&:join)
+          end
+
+          logger.trace("#{@slices} slices completed")
+        end
+
+        def clear(pit_id)
+          logger.debug("close point in time")
+          @client.close_point_in_time(:body => {:id => pit_id} ) if pit_id
+        rescue => e
+          logger.warn("Ignoring close_point_in_time exception", message: e.message, exception: e.class)
+        end
       end
 
     end

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -221,7 +221,7 @@ module LogStash
         end
 
         def clear(pit_id)
-          logger.info("close point in time")
+          logger.info("Closing point in time (PIT)")
           @client.close_point_in_time(:body => {:id => pit_id} ) if pit?(pit_id)
         rescue => e
           logger.debug("Ignoring close_point_in_time exception", message: e.message, exception: e.class)

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module LogStash
+  module Inputs
+    class Elasticsearch
+      class PaginatedSearch
+        include LogStash::Util::Loggable
+
+        def initialize(client, plugin)
+          @client = client
+          @plugin_params = plugin.params
+
+          @index = @plugin_params["index"]
+          @query = LogStash::Json.load(@plugin_params["query"])
+          @scroll = @plugin_params["scroll"]
+          @size = @plugin_params["size"]
+          @slices = @plugin_params["slices"]
+
+          @search_options = {
+            :index => @index,
+            :scroll => @scroll,
+            :size => @size
+          }
+
+          @plugin = plugin
+        end
+
+        def search(output_queue, slice_id=nil)
+          raise NotImplementedError
+        end
+      end
+
+      class Scroll < PaginatedSearch
+        attr_reader :scroll_id
+
+        def prepare_search_options(slice_id)
+          query = @query
+          query = @query.merge('slice' => { 'id' => slice_id, 'max' => @slices}) unless slice_id.nil?
+          @search_options.merge(:body => LogStash::Json.dump(query) )
+        end
+
+        def initial_search(slice_id)
+          options = prepare_search_options(slice_id)
+          @client.search(options)
+        end
+
+        def next_page(scroll_id)
+          @client.scroll(:body => { :scroll_id => scroll_id }, :scroll => @scroll)
+        end
+
+        def process_page(output_queue)
+          r = yield
+          r['hits']['hits'].each { |hit| @plugin.push_hit(hit, output_queue) }
+          [r['hits']['hits'].any?, r['_scroll_id']]
+        end
+
+        def search(output_queue, slice_id=nil)
+          begin
+            log_hash = {}
+            log_hash = log_hash.merge({ slice_id: slice_id, slices: @slices }) unless slice_id.nil?
+
+            logger.info("Search start", log_hash)
+            has_hits, scroll_id = process_page(output_queue) { initial_search(slice_id) }
+
+            while has_hits && scroll_id && !@plugin.stop?
+              logger.debug("Search progress", log_hash)
+              has_hits, scroll_id = process_page(output_queue) { next_page(scroll_id) }
+            end
+
+            logger.info("Search completed", log_hash)
+          ensure
+            clear(scroll_id)
+          end
+        end
+
+        def clear(scroll_id)
+          @client.clear_scroll(:body => { :scroll_id => scroll_id }) if scroll_id
+        rescue => e
+          # ignore & log any clear_scroll errors
+          logger.warn("Ignoring clear_scroll exception", message: e.message, exception: e.class)
+        end
+      end
+
+      class SearchAfter < PaginatedSearch
+
+      end
+    end
+  end
+end

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -224,7 +224,7 @@ module LogStash
           logger.info("close point in time")
           @client.close_point_in_time(:body => {:id => pit_id} ) if pit?(pit_id)
         rescue => e
-          logger.warn("Ignoring close_point_in_time exception", message: e.message, exception: e.class)
+          logger.debug("Ignoring close_point_in_time exception", message: e.message, exception: e.class)
         end
       end
 

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -114,7 +114,7 @@ module LogStash
           @client.clear_scroll(:body => { :scroll_id => scroll_id }) if scroll_id
         rescue => e
           # ignore & log any clear_scroll errors
-          logger.warn("Ignoring clear_scroll exception", message: e.message, exception: e.class)
+          logger.debug("Ignoring clear_scroll exception", message: e.message, exception: e.class)
         end
       end
 

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -119,7 +119,7 @@ module LogStash
       end
 
       class SearchAfter < PaginatedSearch
-        PIT_JOB = "create point in time"
+        PIT_JOB = "create point in time (PIT)"
         SEARCH_AFTER_JOB = "search_after paginated search"
 
         def pit?(id)

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -128,6 +128,10 @@ module LogStash
         PIT_JOB = "create point in time"
         SEARCH_AFTER_JOB = "run search after"
 
+        def pit?(id)
+          !!id&.is_a?(String)
+        end
+
         def create_pit
           logger.debug("create point in time")
           r = @client.open_point_in_time(index: @index, keep_alive: @scroll)
@@ -164,7 +168,7 @@ module LogStash
         def with_pit
           begin
             pit_id = retryable(PIT_JOB) { create_pit }
-            yield pit_id if pit_id.is_a?(String)
+            yield pit_id if pit?(pit_id)
           ensure
             clear(pit_id)
           end
@@ -213,7 +217,7 @@ module LogStash
 
         def clear(pit_id)
           logger.debug("close point in time")
-          @client.close_point_in_time(:body => {:id => pit_id} ) if pit_id
+          @client.close_point_in_time(:body => {:id => pit_id} ) if pit?(pit_id)
         rescue => e
           logger.warn("Ignoring close_point_in_time exception", message: e.message, exception: e.class)
         end

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -75,22 +75,20 @@ module LogStash
         end
 
         def search(output_queue, slice_id=nil)
-          begin
-            log_details = {}
-            log_details = log_details.merge({ slice_id: slice_id, slices: @slices }) unless slice_id.nil?
+          log_details = {}
+          log_details = log_details.merge({ slice_id: slice_id, slices: @slices }) unless slice_id.nil?
 
-            logger.info("Query start", log_details)
-            has_hits, scroll_id = process_page(output_queue) { initial_search(slice_id) }
+          logger.info("Query start", log_details)
+          has_hits, scroll_id = process_page(output_queue) { initial_search(slice_id) }
 
-            while has_hits && scroll_id && !@plugin.stop?
-              logger.debug("Query progress", log_details)
-              has_hits, scroll_id = process_page(output_queue) { next_page(scroll_id) }
-            end
-
-            logger.info("Query completed", log_details)
-          ensure
-            clear(scroll_id)
+          while has_hits && scroll_id && !@plugin.stop?
+            logger.debug("Query progress", log_details)
+            has_hits, scroll_id = process_page(output_queue) { next_page(scroll_id) }
           end
+
+          logger.info("Query completed", log_details)
+        ensure
+          clear(scroll_id)
         end
 
         def retryable_search(output_queue, slice_id=nil)

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -127,7 +127,7 @@ module LogStash
         end
 
         def create_pit
-          logger.info("create point in time")
+          logger.info("Create point in time (PIT)")
           r = @client.open_point_in_time(index: @index, keep_alive: @scroll)
           r['id']
         end

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -46,7 +46,7 @@ module LogStash
       end
 
       class Scroll < PaginatedSearch
-        SCROLL_JOB = "run scroll"
+        SCROLL_JOB = "scroll paginated search"
 
         def search_options(slice_id)
           query = @query

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -28,14 +28,12 @@ module LogStash
         end
 
         def retryable(job_name, &block)
-          begin
-            stud_try = ::LogStash::Helpers::LoggableTry.new(logger, job_name)
-            stud_try.try((@retries + 1).times) { yield }
-          rescue => e
-            error_details = {:message => e.message, :cause => e.cause}
-            error_details[:backtrace] = e.backtrace if logger.debug?
-            logger.error("Tried #{job_name} unsuccessfully", error_details)
-          end
+          stud_try = ::LogStash::Helpers::LoggableTry.new(logger, job_name)
+          stud_try.try((@retries + 1).times) { yield }
+        rescue => e
+          error_details = {:message => e.message, :cause => e.cause}
+          error_details[:backtrace] = e.backtrace if logger.debug?
+          logger.error("Tried #{job_name} unsuccessfully", error_details)
         end
 
         def retryable_search(output_queue)

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -120,7 +120,7 @@ module LogStash
 
       class SearchAfter < PaginatedSearch
         PIT_JOB = "create point in time"
-        SEARCH_AFTER_JOB = "run search after"
+        SEARCH_AFTER_JOB = "search_after paginated search"
 
         def pit?(id)
           !!id&.is_a?(String)

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -16,12 +16,6 @@ module LogStash
           @size = @plugin_params["size"]
           @slices = @plugin_params["slices"]
 
-          @search_options = {
-            :index => @index,
-            :scroll => @scroll,
-            :size => @size
-          }
-
           @plugin = plugin
         end
 
@@ -31,12 +25,14 @@ module LogStash
       end
 
       class Scroll < PaginatedSearch
-        attr_reader :scroll_id
-
         def prepare_search_options(slice_id)
           query = @query
           query = @query.merge('slice' => { 'id' => slice_id, 'max' => @slices}) unless slice_id.nil?
-          @search_options.merge(:body => LogStash::Json.dump(query) )
+          {
+            :index => @index,
+            :scroll => @scroll,
+            :size => @size
+          }.merge(:body => LogStash::Json.dump(query) )
         end
 
         def initial_search(slice_id)

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -171,12 +171,10 @@ module LogStash
         end
 
         def with_pit
-          begin
-            pit_id = retryable(PIT_JOB) { create_pit }
-            yield pit_id if pit?(pit_id)
-          ensure
-            clear(pit_id)
-          end
+          pit_id = retryable(PIT_JOB) { create_pit }
+          yield pit_id if pit?(pit_id)
+        ensure
+          clear(pit_id)
         end
 
         def search(output_queue:, slice_id: nil, pit_id:)

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.18.0'
+  s.version         = '4.19.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -402,8 +402,8 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
           expect(client).to receive(:search).with(hash_including(:body => slice1_query)).and_return(slice1_response0)
           expect(client).to receive(:scroll).with(hash_including(:body => { :scroll_id => slice1_scroll1 })).and_return(slice1_response1)
 
-          synchronize_method!(plugin, :scroll_request)
-          synchronize_method!(plugin, :search_request)
+          synchronize_method!(plugin.instance_variable_get(:@paginated_search), :next_page)
+          synchronize_method!(plugin.instance_variable_get(:@paginated_search), :initial_search)
         end
 
         let(:client) { Elasticsearch::Client.new }
@@ -472,8 +472,8 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
           expect(client).to receive(:search).with(hash_including(:body => slice1_query)).and_return(slice1_response0)
           expect(client).to receive(:scroll).with(hash_including(:body => { :scroll_id => slice1_scroll1 })).and_raise("boom")
 
-          synchronize_method!(plugin, :scroll_request)
-          synchronize_method!(plugin, :search_request)
+          synchronize_method!(plugin.instance_variable_get(:@paginated_search), :next_page)
+          synchronize_method!(plugin.instance_variable_get(:@paginated_search), :initial_search)
         end
 
         let(:client) { Elasticsearch::Client.new }

--- a/spec/inputs/integration/elasticsearch_spec.rb
+++ b/spec/inputs/integration/elasticsearch_spec.rb
@@ -20,10 +20,7 @@ describe LogStash::Inputs::Elasticsearch, :integration => true do
   let(:password) { ENV['ELASTIC_PASSWORD'] || 'abc123' }
   let(:ca_file) { "spec/fixtures/test_certs/ca.crt" }
 
-  let(:es_url) do
-    es_url = ESHelper.get_host_port
-    SECURE_INTEGRATION ? "https://#{es_url}" : "http://#{es_url}"
-  end
+  let(:es_url) { "http#{SECURE_INTEGRATION ? 's' : nil}://#{ESHelper.get_host_port}" }
 
   let(:curl_args) do
     config['user'] ? "-u #{config['user']}:#{config['password']}" : ''

--- a/spec/inputs/integration/elasticsearch_spec.rb
+++ b/spec/inputs/integration/elasticsearch_spec.rb
@@ -63,10 +63,6 @@ describe LogStash::Inputs::Elasticsearch, :integration => true do
   end
 
   describe 'against an unsecured elasticsearch', integration: true do
-    before(:each) do
-      plugin.register
-    end
-
     it_behaves_like 'an elasticsearch index plugin'
   end
 
@@ -136,4 +132,10 @@ describe LogStash::Inputs::Elasticsearch, :integration => true do
 
   end
 
+  describe 'slice', integration: true do
+    let(:config) { super().merge('slices' => 2, 'size' => 2) }
+    let(:plugin) { described_class.new(config) }
+
+    it_behaves_like 'an elasticsearch index plugin'
+  end
 end

--- a/spec/inputs/integration/elasticsearch_spec.rb
+++ b/spec/inputs/integration/elasticsearch_spec.rb
@@ -43,6 +43,8 @@ describe LogStash::Inputs::Elasticsearch, :integration => true do
     ESHelper.curl_and_get_json_response "#{es_url}/_index_template/*", method: 'DELETE', args: curl_args
     # This can fail if there are no indexes, ignore failure.
     ESHelper.curl_and_get_json_response( "#{es_url}/_index/*", method: 'DELETE', args: curl_args) rescue nil
+    ESHelper.curl_and_get_json_response( "#{es_url}/logs", method: 'DELETE', args: curl_args) rescue nil
+    ESHelper.curl_and_get_json_response "#{es_url}/_refresh", method: 'POST', args: curl_args
   end
 
   shared_examples 'an elasticsearch index plugin' do
@@ -53,6 +55,7 @@ describe LogStash::Inputs::Elasticsearch, :integration => true do
     it 'should retrieve json event from elasticsearch' do
       queue = []
       plugin.run(queue)
+      expect(queue.size).to eq(10)
       event = queue.pop
       expect(event).to be_a(LogStash::Event)
       expect(event.get("response")).to eql(404)

--- a/spec/inputs/paginated_search_spec.rb
+++ b/spec/inputs/paginated_search_spec.rb
@@ -1,0 +1,129 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/elasticsearch/paginated_search"
+
+describe "Paginated search" do
+  let(:es_client) { double("Elasticsearch::Client") }
+  let(:settings) { { "index" => "logs", "query" => "{ \"sort\": [ \"_doc\" ] }", "scroll" => "1m", "retries" => 0, "size" => 1000 } }
+  let(:plugin) { double("LogStash::Inputs::Elasticsearch", params: settings, pipeline_id: "main", stop?: false) }
+  let(:pit_id) { "08fsAwILcmVzaGFyZC0yZmIWdzFnbl" }
+
+  describe "search after" do
+    subject do
+      LogStash::Inputs::Elasticsearch::SearchAfter.new(es_client, plugin)
+    end
+
+    describe "search options" do
+      context "query without sort" do
+        let(:settings) { super().merge({"query" => "{\"match_all\": {} }"}) }
+
+        it "adds default sort" do
+          options = subject.search_options(pit_id: pit_id)
+          expect(options[:body][:sort]).to match({"_shard_doc": "asc"})
+        end
+      end
+
+      context "customize settings" do
+        let(:size) { 2 }
+        let(:slices) { 4 }
+        let(:settings) { super().merge({"slices" => slices, "size" => size}) }
+
+        it "gives updated options" do
+          slice_id = 1
+          search_after = [0, 0]
+          options = subject.search_options(pit_id: pit_id, slice_id: slice_id, search_after: search_after)
+          expect(options[:size]).to match(size)
+          expect(options[:body][:slice]).to match({:id => slice_id, :max => slices})
+          expect(options[:body][:search_after]).to match(search_after)
+        end
+      end
+    end
+
+    describe "search" do
+      let(:queue) { double("queue") }
+      let(:doc1) do
+        {
+          "_index" => "logstash",
+          "_type" => "logs",
+          "_id" => "C5b2xLQwTZa76jBmHIbwHQ",
+          "_score" => 1.0,
+          "_source" => { "message" => ["Halloween"] },
+          "sort" => [0, 0]
+        }
+      end
+      let(:first_resp) do
+        {
+          "pit_id" => pit_id,
+          "took" => 27,
+          "timed_out" => false,
+          "_shards" => {
+            "total" => 2,
+            "successful" => 2,
+            "skipped" => 0,
+            "failed" => 0
+          },
+          "hits" => {
+            "total" => {
+              "value" => 500,
+              "relation" => "eq"
+            },
+            "hits" => [ doc1 ]
+          }
+        }
+      end
+      let(:last_resp) do
+        {
+          "pit_id" => pit_id,
+          "took" => 27,
+          "timed_out" => false,
+          "_shards" => {
+            "total" => 2,
+            "successful" => 2,
+            "skipped" => 0,
+            "failed" => 0
+          },
+          "hits" => {
+            "total" => {
+              "value" => 500,
+              "relation" => "eq"
+            },
+            "hits" => [ ] # empty hits to break the loop
+          }
+        }
+      end
+
+      context "happy case" do
+        it "runs" do
+          expect(es_client).to receive(:search).with(instance_of(Hash)).and_return(first_resp, last_resp)
+          expect(plugin).to receive(:push_hit).with(doc1, queue).once
+          subject.search(output_queue: queue, pit_id: pit_id)
+        end
+      end
+
+      context "with exception" do
+        it "closes pit" do
+          expect(es_client).to receive(:open_point_in_time).once.and_return({ "id" => pit_id})
+          expect(plugin).to receive(:push_hit).with(doc1, queue).once
+          expect(es_client).to receive(:search).with(instance_of(Hash)).once.and_return(first_resp)
+          expect(es_client).to receive(:search).with(instance_of(Hash)).once.and_raise(Manticore::UnknownException)
+          expect(es_client).to receive(:close_point_in_time).with(any_args).once.and_return(nil)
+          subject.retryable_search(queue)
+        end
+      end
+
+      context "with slices" do
+        let(:slices) { 2 }
+        let(:settings) { super().merge({"slices" => slices}) }
+
+        it "runs two slices" do
+          expect(es_client).to receive(:open_point_in_time).once.and_return({ "id" => pit_id})
+          expect(plugin).to receive(:push_hit).with(any_args).twice
+          expect(Thread).to receive(:new).and_call_original.exactly(slices).times
+          expect(es_client).to receive(:search).with(instance_of(Hash)).and_return(first_resp, last_resp, first_resp, last_resp)
+          expect(es_client).to receive(:close_point_in_time).with(any_args).once.and_return(nil)
+          subject.retryable_slice_search(queue)
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This commit introduces the `search_api` option to enable support for both `search_after` and `scroll`. 

| `search_api`  | description  |
|-----------|-----------|
| `auto`    | Default value. It uses `search_after` for Elasticsearch 8 and newer versions, otherwise, it falls back to the `scroll` API    |
| `search_after`    | Create a point in time for search, which is the recommended way to do paginated search since 7.10   |
| `scroll`   | Uses scroll API to search, which is the previous way to search    |

When `search_after` is utilized, if the query doesn't specify a sort field, a default sort of `{ "sort": { "_shard_doc": "asc" } }` will be added to the query. By default, Elasticsearch adds a sort field "_shard_doc" on top of existing sort implicitly as a tie-breakers.

The scroll search has been refactored and is expected to function the same, with only minor changes made to the logging messages.

### Backward compatibility
There is one concern to make search_after as the default. The scroll API doesn't require a sort field in query, while search_after needs the last sort value from the return documents for the next search. When the plugin is updated, if the query has sort, it is fine as both APIs should return data in the same order. If the query doesn't has sort, I believe user doesn't concern the ordering, hence, adding a default sort field "_shard_doc" should be fine.
