### PR TITLE
Doc: Fix typo in heading id 

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -381,7 +381,7 @@ This parameter controls the keepalive time in seconds of the scrolling
 request and initiates the scrolling process. The timeout applies per
 round trip (i.e. between the previous scroll request, to the next).
 
-[id="plugins-{type}s-{plugin}-seearch_api"]
+[id="plugins-{type}s-{plugin}-search_api"]
 ===== `search_api`
 
 * Value can be any of: `auto`, `search_after`, `scroll`


### PR DESCRIPTION
The head ID introduced in # contains a typo. Links can't resolve, and it's causing docs failures. 

No version bump required. This fix will be in place in source the next time we release the gem. 

