### PR TITLE
Support aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.20.0
+  - Added `response_type` configuration option to allow aggregations to be executed:w
+
 ## 4.19.1
   - Plugin version bump to pick up docs fix in  [#199](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/199) required to clear build error in docgen. [#200](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/200)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.20.0
-  - Added `response_type` configuration option to allow aggregations to be executed
+  - Added `response_type` configuration option to allow processing result of aggregations
 
 ## 4.19.1
   - Plugin version bump to pick up docs fix in  [#199](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/199) required to clear build error in docgen. [#200](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.20.0
-  - Added `response_type` configuration option to allow processing result of aggregations
+  - Added `response_type` configuration option to allow processing result of aggregations [#202](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/202)
 
 ## 4.19.1
   - Plugin version bump to pick up docs fix in  [#199](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/199) required to clear build error in docgen. [#200](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.20.0
-  - Added `response_type` configuration option to allow aggregations to be executed:w
+  - Added `response_type` configuration option to allow aggregations to be executed
 
 ## 4.19.1
   - Plugin version bump to pick up docs fix in  [#199](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/199) required to clear build error in docgen. [#200](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/200)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -115,6 +115,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-response_type>> |<<string,string>>, one of `["hits","aggregations"]`|No
 | <<plugins-{type}s-{plugin}-request_timeout_seconds>> | <<number,number>>|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-scroll>> |<<string,string>>|No

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -338,6 +338,20 @@ documentation] for more information.
 When <<plugins-{type}s-{plugin}-search_api>> resolves to `search_after` and the query does not specify `sort`,
 the default sort `'{ "sort": { "_shard_doc": "asc" } }'` will be added to the query. Please refer to the {ref}/paginate-search-results.html#search-after[Elasticsearch search_after] parameter to know more.
 
+[id="plugins-{type}s-{plugin}-response_type"]
+===== `response_type`
+
+  * Value can be any of: `hits`, `aggregations`
+  * Default value is `hits`
+
+Which part of the result to transform into Logstash events when processing the
+response from the query.
+The default `hits` will generate one event per returned document (i.e. "hit").
+When set to `aggregations`, a single Logstash event will be generated with the
+contents of the `aggregations` object of the query's response. In this case the
+`hits` object will be ignored. The parameter `size` will be always be set to
+0 regardless of the default or user-defined value set in this plugin.
+
 [id="plugins-{type}s-{plugin}-request_timeout_seconds"]
 ===== `request_timeout_seconds`
 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -295,7 +295,6 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
       }
     elsif @response_type == 'aggregations'
       @options = {
-        :body  => @base_query,
         :index => @index,
         :size  => @size
       }
@@ -401,7 +400,10 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   def do_run_aggregation(output_queue)agg_query   = @base_query
     logger.info("Aggregation starting")
 
-    r = search_request(@options)
+    agg_query   = @base_query
+    agg_options = @options.merge(:body => LogStash::Json.dump(agg_query) )
+
+    r = search_request(agg_options)
     aggs = r['aggregations']
 
     event = targeted_event_factory.new_event aggs

--- a/lib/logstash/inputs/elasticsearch/aggregation.rb
+++ b/lib/logstash/inputs/elasticsearch/aggregation.rb
@@ -1,0 +1,33 @@
+require 'logstash/helpers/loggable_try'
+
+module LogStash
+  module Inputs
+    class Elasticsearch
+      class Aggregation
+        include LogStash::Util::Loggable
+
+        def initialize(client, plugin)
+          @client = client
+          @plugin_params = plugin.params
+
+          @scroll = @plugin_params["scroll"]
+          @size = @plugin_params["size"]
+          @index = @plugin_params["index"]
+          @query = @plugin_params["query"]
+          @agg_options = {
+            :index => @index,
+            :size  => @size
+          }.merge(:body => @query)
+
+          @plugin = plugin
+        end
+
+        def do_run(output_queue)
+          logger.info("Aggregation starting")
+          r = @client.search(@agg_options)
+          @plugin.push_hit r, output_queue, 'aggregations'
+        end
+      end
+    end
+  end
+end

--- a/lib/logstash/inputs/elasticsearch/aggregation.rb
+++ b/lib/logstash/inputs/elasticsearch/aggregation.rb
@@ -34,10 +34,10 @@ module LogStash
 
         def do_run(output_queue)
           logger.info("Aggregation starting")
-          retryable(AGGREGATION_JOB) do
-            r = @client.search(@agg_options)
-            @plugin.push_hit(r, output_queue, 'aggregations')
+          r = retryable(AGGREGATION_JOB) do
+            @client.search(@agg_options)
           end
+          @plugin.push_hit(r, output_queue, 'aggregations')
         end
       end
     end

--- a/lib/logstash/inputs/elasticsearch/aggregation.rb
+++ b/lib/logstash/inputs/elasticsearch/aggregation.rb
@@ -6,26 +6,38 @@ module LogStash
       class Aggregation
         include LogStash::Util::Loggable
 
+        AGGREGATION_JOB = "aggregation"
+
         def initialize(client, plugin)
           @client = client
           @plugin_params = plugin.params
 
-          @scroll = @plugin_params["scroll"]
           @size = @plugin_params["size"]
-          @index = @plugin_params["index"]
           @query = @plugin_params["query"]
+          @retries = @plugin_params["retries"]
           @agg_options = {
             :index => @index,
-            :size  => @size
+            :size  => 0
           }.merge(:body => @query)
 
           @plugin = plugin
         end
 
+        def retryable(job_name, &block)
+          stud_try = ::LogStash::Helpers::LoggableTry.new(logger, job_name)
+          stud_try.try((@retries + 1).times) { yield }
+        rescue => e
+          error_details = {:message => e.message, :cause => e.cause}
+          error_details[:backtrace] = e.backtrace if logger.debug?
+          logger.error("Tried #{job_name} unsuccessfully", error_details)
+        end
+
         def do_run(output_queue)
           logger.info("Aggregation starting")
-          r = @client.search(@agg_options)
-          @plugin.push_hit r, output_queue, 'aggregations'
+          retryable(AGGREGATION_JOB) do
+            r = @client.search(@agg_options)
+            @plugin.push_hit(r, output_queue, 'aggregations')
+          end
         end
       end
     end

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.19.1'
+  s.version         = '4.20.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -1033,7 +1033,62 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
         runner.join if runner
       end
     end
+  end
 
+  context "aggregations" do
+    let(:config) do
+      {
+        'hosts'         => ["localhost"],
+        'query'         => '{ "query": {}, "size": 0, "aggs":{"total_count": { "value_count": { "field": "type" }}, "empty_count": { "sum": { "field": "_meta.empty_event" }}}}',
+        'response_type' => 'aggregations',
+        'size'          => 0
+      }
+    end
+
+    let(:mock_response) do
+      {
+        "took" => 27,
+        "timed_out" => false,
+        "_shards" => {
+          "total" => 169,
+          "successful" => 169,
+          "skipped" => 0,
+          "failed" => 0
+        },
+        "hits" => {
+          "total" => 10,
+          "max_score" => 1.0,
+          "hits" => []
+        },
+        "aggregations" => {
+          "total_counter" => {
+            "value" => 10
+          },
+          "empty_counter" => {
+            "value" => 5
+          },
+        }
+      }
+    end
+
+    before(:each) do
+      client = Elasticsearch::Client.new
+
+      expect(Elasticsearch::Client).to receive(:new).with(any_args).and_return(client)
+      expect(client).to receive(:search).with(any_args).and_return(mock_response)
+      expect(client).to receive(:ping)
+    end
+
+    before { plugin.register }
+
+    it 'creates the events from the aggregations' do
+      plugin.run queue
+      event = queue.pop
+
+      expect(event).to be_a(LogStash::Event)
+      expect(event.get("[total_counter][value]")).to eql 10
+      expect(event.get("[empty_counter][value]")).to eql 5
+    end
   end
 
   context "retries" do


### PR DESCRIPTION
Add `response_type` configuration option to allow processing result of aggregations.

The default `hits` will generate one event per returned document (i.e. "hit"), which is the current behavior.

When set to `aggregations`, a single Logstash event will be generated with the contents of the `aggregations` object of the query's response. In this case the `hits` object will be ignored.
The parameter `size` will be always be set to 0 regardless of the default or user-defined value set in this plugin.

builds upon and replaces #197 
closes #58  