### PR TITLE
Introduce cursor tracking akin to jdbc input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.0
+  - Add "cursor"-like index tracking [#205](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/205)
+
 ## 5.0.2
   - Add elastic-transport client support used in elasticsearch-ruby 8.x [#223](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/223)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -217,7 +217,7 @@ added by an Elasticsearch ingest pipeline, and the `tracking_field` capability o
 With this setup, as new documents are indexed an `test-*` index, the next scheduled run will:
 
 . select all new documents since the last observed value of the tracking field;
-. use <<point-in-time-api,Point in time (PIT)>> + <<search-after, Search after>> to paginate through all the data;
+. use {ref}/point-in-time-api.html#point-in-time-api[Point in time (PIT)] + {ref}/paginate-search-results.html#search-after[Search after] to paginate through all the data;
 . update the value of the field at the end of the pagination.
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -106,7 +106,6 @@ Common causes are:
 [id="plugins-{type}s-{plugin}-cursor"]
 ==== Tracking a field's value across runs
 
-NOTE: experimental:[] `tracking_field` and related settings are experimental and subject to change in the future
 .Technical Preview: Tracking a field's value
 ****
 The feature that allows tracking a field's value across runs is in _Technical Preview_.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -49,6 +49,119 @@ This would create an Elasticsearch query with the following format:
     }'
 
 
+[id="plugins-{type}s-{plugin}-cursor"]
+==== Tracking a field's value across runs
+
+It is sometimes desirable to track the value of a particular field between two jobs:
+* avoid re-processing the entire result set of a long query after an unplanned restart
+* only grab new data from an index instead of processing the entire set on each job
+
+For this, the Elasticsearch input plugin provides the <<tracking_field>> and <<tracking_field_seed>> options.
+When <<tracking_field>> is set, the plugin will record the value of that field for the last document retrieved in a run into
+a file (location defaults to <<last_run_metadata_path>>.
+
+The user can then inject this value in the query using the placeholder `:last_value`. The value will be injected into the query
+before execution, and the updated after the query completes, assuming new data was found.
+
+The plugin also offers another placeholder called `:present` used to inject the nano-second based
+
+This feature works best when:
+* the query sorts by the tracking field
+* the field type has enough resolution so that two events are unlikely to have the same value for the field
+
+A suggestion is to use a tracking field that has nanosecond second precision, like
+https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html[date nanoseconds] field type.
+
+A good use case for this feature is to track new data in an index, which can be achieved by:
+
+1. create ingest pipeline that adds Elasticsearch's `_ingest.timestamp` field to the documents as `event.ingested`:
+
+[source, json]
+    PUT _ingest/pipeline/my-pipeline
+    {
+      "processors": [
+              {
+            "script": {
+              "lang": "painless",
+              "source": "ctx.putIfAbsent(\"event\", [:]); ctx.event.ingested = metadata().now.format(DateTimeFormatter.ISO_INSTANT);"
+            }
+          }
+      ]
+    }
+
+
+2. create an index mapping where the tracking field is of date nanosecond type and invokes the defined pipeline:
+
+[source, json]
+    PUT /_template/my_template
+    {
+      "index_patterns": ["test-*"],
+      "settings": {
+        "index.default_pipeline": "my-pipeline",
+      },
+      "mappings": {
+        "properties": {
+          "event": {
+            "properties": {
+              "ingested": {
+                "type": "date_nanos",
+                "format": "strict_date_optional_time_nanos"
+              }
+            }
+          }
+        }
+      }
+    }
+
+3. define a query that looks at all data of the indices, sorted by the tracking field, and with a range filter since the last value seen until present:
+
+[source,json]
+{
+  "query": {
+    "range": {
+      "event.ingested": {
+        "gt": ":last_value",
+        "lt": ":present"
+      }
+    }
+  },
+  "sort": [
+    {
+      "event.ingested": {
+        "order": "asc",
+        "format": "strict_date_optional_time_nanos",
+        "numeric_type": "date_nanos"
+      }
+    }
+  ]
+}
+
+4. configure the Elasticsearch input to query the indices with the query defined above, every minute, and track the `event.ingested` field:
+
+[source, ruby]
+    input {
+      elasticsearch {
+        id => tail_test_index
+        hosts => [ 'https://..']
+        api_key => '....'
+        index => 'test-*'
+        query => '{ "query": { "range": { "event.ingested": { "gt": ":last_value", "lt": ":present"}}}, "sort": [ { "event.ingested": {"order": "asc", "format": "strict_date_optional_time_nanos", "numeric_type" : "date_nanos" } } ] }'
+        tracking_field => "[event][ingested]"
+        # set a seed value to a value known to be older than any value of `event.ingested`
+        tracking_field_seed => "1980-01-01T23:59:59.999999999Z"
+        slices => 5 # optional use of slices to speed data processing, should be less than number of primary shards
+        schedule => '* * * * *' # every minute
+        schedule_overlap => false # don't accumulate jobs if one takes longer than 1 minute
+      }
+    }
+
+With this setup, as new documents are indexed an `test-*` index, the next scheduled run will:
+
+1. select all new documents since the last observed value of the tracking field;
+2. use PIT+search_after to paginate through all the data;
+3. update the value of the field at the end of the pagination.
+
+[id="plugins-{type}s-{plugin}-scheduling"]
 ==== Scheduling
 
 Input from this plugin can be scheduled to run periodically according to a specific
@@ -658,6 +771,8 @@ Which field from the last event of a previous run will be used a cursor value fo
 The value of this field is injected into each query if the query uses the placeholder `:last_value`.
 For the first query after a pipeline is started, the value used is either read from <<last_run_metadata_path>> file,
 or taken from <<tracking_field_seed>> setting.
+
+Note: The tracking value is updated only after the PIT+search_after run completes, it won't update during the search_after pagination. This is to allow use of slices.
 
 [id="plugins-{type}s-{plugin}-tracking_field_seed"]
 ===== `tracking_field_seed`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -454,7 +454,9 @@ referencing multiple indices.
   * There is no default value for this setting.
 
 The path to store the last observed value of the tracking field, when used.
-By default this file is stored as `<path.data>/plugins/inputs/elasticsearch/<pipeline.id>.last_run`.
+By default this file is stored as `<path.data>/plugins/inputs/elasticsearch/last_run_value`.
+
+This setting should point to file, not a directory, and Logstash must have read+write access to this file.
 
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -117,18 +117,21 @@ When <<plugins-{type}s-{plugin}-tracking_field>> is set, the plugin will record 
 a file (location defaults to <<plugins-{type}s-{plugin}-last_run_metadata_path>>).
 
 The user can then inject this value in the query using the placeholder `:last_value`. The value will be injected into the query
-before execution, and the updated after the query completes, assuming new data was found.
+before execution, and the updated after the query completes if new data was found.
 
 This feature works best when:
-* the query sorts by the tracking field
-* the field type has enough resolution so that two events are unlikely to have the same value for the field
 
-The plugin also offers another placeholder called `:present` used to inject the nano-second based value of "now-30s".
+. the query sorts by the tracking field;
+. the timestamp field is added by {es};
+. the field type has enough resolution so that two events are unlikely to have the same value.
 
-A suggestion is to use a tracking field that has nanosecond second precision, like
-https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html[date nanoseconds] field type.
+It is recommended to use a tracking field whose type is https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html[date nanoseconds].
+If the tracking field is of this data type, an extra placeholder called `:present` can be used to inject the nano-second based value of "now-30s".
+This placeholder is useful as the right-hand side of a range filter, allowing the collection of
+new data but leaving partially-searcheable bulk request data to the next scheduled job.
 
-A good use case for this feature is to track new data in an index, which can be achieved by:
+Below is a series of steps to help set up the "tailing" of data being written to a set of indices, using a date nanosecond field
+added by an Elasticsearch ingest pipeline, and the `tracking_field` capability of this plugin.
 
 . create ingest pipeline that adds Elasticsearch's `_ingest.timestamp` field to the documents as `event.ingested`:
 
@@ -205,9 +208,7 @@ A good use case for this feature is to track new data in an index, which can be 
         index => 'test-*'
         query => '{ "query": { "range": { "event.ingested": { "gt": ":last_value", "lt": ":present"}}}, "sort": [ { "event.ingested": {"order": "asc", "format": "strict_date_optional_time_nanos", "numeric_type" : "date_nanos" } } ] }'
         tracking_field => "[event][ingested]"
-        # set a seed value to a value known to be older than any value of `event.ingested`
-        tracking_field_seed => "1980-01-01T23:59:59.999999999Z"
-        slices => 5 # optional use of slices to speed data processing, should be less than number of primary shards
+        slices => 5 # optional use of slices to speed data processing, should be equal to or less than number of primary shards
         schedule => '* * * * *' # every minute
         schedule_overlap => false # don't accumulate jobs if one takes longer than 1 minute
       }
@@ -216,7 +217,7 @@ A good use case for this feature is to track new data in an index, which can be 
 With this setup, as new documents are indexed an `test-*` index, the next scheduled run will:
 
 . select all new documents since the last observed value of the tracking field;
-. use PIT+search_after to paginate through all the data;
+. use <<point-in-time-api,Point in time (PIT)>> + <<search-after, Search after>> to paginate through all the data;
 . update the value of the field at the end of the pagination.
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -547,7 +547,7 @@ exactly once.
   * Default value is `true`
 
 Whether to allow queuing of a scheduled run if a run is occurring.
-While this is ideal for ensuring a new run happens immediatelly after the previous on finishes if there
+While this is ideal for ensuring a new run happens immediately after the previous on finishes if there
 is a lot of work to do, but given the queue is unbounded it may lead to an out of memory over long periods of time
 if the queue grows continuously.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,9 +56,9 @@ It is sometimes desirable to track the value of a particular field between two j
 * avoid re-processing the entire result set of a long query after an unplanned restart
 * only grab new data from an index instead of processing the entire set on each job
 
-For this, the Elasticsearch input plugin provides the <<tracking_field>> and <<tracking_field_seed>> options.
-When <<tracking_field>> is set, the plugin will record the value of that field for the last document retrieved in a run into
-a file (location defaults to <<last_run_metadata_path>>.
+For this, the Elasticsearch input plugin provides the <<plugins-{type}s-{plugin}-tracking_field>> and <<plugins-{type}s-{plugin}-tracking_field_seed>> options.
+When <<plugins-{type}s-{plugin}-tracking_field>> is set, the plugin will record the value of that field for the last document retrieved in a run into
+a file (location defaults to <<plugins-{type}s-{plugin}-last_run_metadata_path>>).
 
 The user can then inject this value in the query using the placeholder `:last_value`. The value will be injected into the query
 before execution, and the updated after the query completes, assuming new data was found.
@@ -771,8 +771,8 @@ It is also possible to target an entry in the event's metadata, which will be av
 
 Which field from the last event of a previous run will be used a cursor value for the following run.
 The value of this field is injected into each query if the query uses the placeholder `:last_value`.
-For the first query after a pipeline is started, the value used is either read from <<last_run_metadata_path>> file,
-or taken from <<tracking_field_seed>> setting.
+For the first query after a pipeline is started, the value used is either read from <<plugins-{type}s-{plugin}-last_run_metadata_path>> file,
+or taken from <<plugins-{type}s-{plugin}-tracking_field_seed>> setting.
 
 Note: The tracking value is updated only after the PIT+search_after run completes, it won't update during the search_after pagination. This is to allow use of slices.
 
@@ -782,7 +782,7 @@ Note: The tracking value is updated only after the PIT+search_after run complete
 * Value type is <<string,string>>
 * There is no default value for this setting.
 
-The starting value for the <<tracking_field>> if there is no <<last_run_metadata_path>> already.
+The starting value for the <<plugins-{type}s-{plugin}-tracking_field>> if there is no <<plugins-{type}s-{plugin}-last_run_metadata_path>> already.
 For a nanosecond timestamp based field, a suggested seed value something like `1980-01-01T23:59:59.999999999Z`.
 
 [id="plugins-{type}s-{plugin}-user"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -48,9 +48,65 @@ This would create an Elasticsearch query with the following format:
       "sort": [ "_doc" ]
     }'
 
+[id="plugins-{type}s-{plugin}-scheduling"]
+==== Scheduling
+
+Input from this plugin can be scheduled to run periodically according to a specific
+schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
+The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
+
+Examples:
+
+|==========================================================
+| `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
+| `0 * * * *`                 | will execute on the 0th minute of every hour every day.
+| `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
+|==========================================================
+
+
+Further documentation describing this syntax can be found
+https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
+
+
+[id="plugins-{type}s-{plugin}-auth"]
+==== Authentication
+
+Authentication to a secure Elasticsearch cluster is possible using _one_ of the following options:
+
+* <<plugins-{type}s-{plugin}-user>> AND <<plugins-{type}s-{plugin}-password>>
+* <<plugins-{type}s-{plugin}-cloud_auth>>
+* <<plugins-{type}s-{plugin}-api_key>>
+
+[id="plugins-{type}s-{plugin}-autz"]
+==== Authorization
+
+Authorization to a secure Elasticsearch cluster requires `read` permission at index level and `monitoring` permissions at cluster level.
+The `monitoring` permission at cluster level is necessary to perform periodic connectivity checks.
+
+[id="plugins-{type}s-{plugin}-ecs"]
+==== Compatibility with the Elastic Common Schema (ECS)
+
+When ECS compatibility is disabled, `docinfo_target` uses the `"@metadata"` field as a default, with ECS enabled the plugin
+uses a naming convention `"[@metadata][input][elasticsearch]"` as a default target for placing document information.
+
+The plugin logs a warning when ECS is enabled and `target` isn't set.
+
+TIP: Set the `target` option to avoid potential schema conflicts.
+
+[id="plugins-{type}s-{plugin}-failure-handling"]
+==== Failure handling
+
+When this input plugin cannot create a structured `Event` from a hit result, it will instead create an `Event` that is tagged with `_elasticsearch_input_failure` whose `[event][original]` is a JSON-encoded string representation of the entire hit.
+
+Common causes are:
+
+ - When the hit result contains top-level fields that are {logstash-ref}/processing.html#reserved-fields[reserved in Logstash] but do not have the expected shape. Use the <<plugins-{type}s-{plugin}-target>> directive to avoid conflicts with the top-level namespace.
+ - When <<plugins-{type}s-{plugin}-docinfo>> is enabled and the docinfo fields cannot be merged into the hit result. Combine <<plugins-{type}s-{plugin}-target>> and <<plugins-{type}s-{plugin}-docinfo_target>> to avoid conflict.
 
 [id="plugins-{type}s-{plugin}-cursor"]
 ==== Tracking a field's value across runs
+
+NOTE: experimental:[] `tracking_field` and related settings are experimental and subject to change in the future
 
 It is sometimes desirable to track the value of a particular field between two jobs:
 * avoid re-processing the entire result set of a long query after an unplanned restart
@@ -162,61 +218,6 @@ With this setup, as new documents are indexed an `test-*` index, the next schedu
 . select all new documents since the last observed value of the tracking field;
 . use PIT+search_after to paginate through all the data;
 . update the value of the field at the end of the pagination.
-
-[id="plugins-{type}s-{plugin}-scheduling"]
-==== Scheduling
-
-Input from this plugin can be scheduled to run periodically according to a specific
-schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
-The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
-
-Examples:
-
-|==========================================================
-| `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
-| `0 * * * *`                 | will execute on the 0th minute of every hour every day.
-| `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
-|==========================================================
-
-
-Further documentation describing this syntax can be found
-https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
-
-
-[id="plugins-{type}s-{plugin}-auth"]
-==== Authentication
-
-Authentication to a secure Elasticsearch cluster is possible using _one_ of the following options:
-
-* <<plugins-{type}s-{plugin}-user>> AND <<plugins-{type}s-{plugin}-password>>
-* <<plugins-{type}s-{plugin}-cloud_auth>>
-* <<plugins-{type}s-{plugin}-api_key>>
-
-[id="plugins-{type}s-{plugin}-autz"]
-==== Authorization
-
-Authorization to a secure Elasticsearch cluster requires `read` permission at index level and `monitoring` permissions at cluster level.
-The `monitoring` permission at cluster level is necessary to perform periodic connectivity checks.
-
-[id="plugins-{type}s-{plugin}-ecs"]
-==== Compatibility with the Elastic Common Schema (ECS)
-
-When ECS compatibility is disabled, `docinfo_target` uses the `"@metadata"` field as a default, with ECS enabled the plugin
-uses a naming convention `"[@metadata][input][elasticsearch]"` as a default target for placing document information.
-
-The plugin logs a warning when ECS is enabled and `target` isn't set.
-
-TIP: Set the `target` option to avoid potential schema conflicts.
-
-[id="plugins-{type}s-{plugin}-failure-handling"]
-==== Failure handling
-
-When this input plugin cannot create a structured `Event` from a hit result, it will instead create an `Event` that is tagged with `_elasticsearch_input_failure` whose `[event][original]` is a JSON-encoded string representation of the entire hit.
-
-Common causes are:
-
- - When the hit result contains top-level fields that are {logstash-ref}/processing.html#reserved-fields[reserved in Logstash] but do not have the expected shape. Use the <<plugins-{type}s-{plugin}-target>> directive to avoid conflicts with the top-level namespace.
- - When <<plugins-{type}s-{plugin}-docinfo>> is enabled and the docinfo fields cannot be merged into the hit result. Combine <<plugins-{type}s-{plugin}-target>> and <<plugins-{type}s-{plugin}-docinfo_target>> to avoid conflict.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Input configuration options

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -776,7 +776,7 @@ The value of this field is injected into each query if the query uses the placeh
 For the first query after a pipeline is started, the value used is either read from <<plugins-{type}s-{plugin}-last_run_metadata_path>> file,
 or taken from <<plugins-{type}s-{plugin}-tracking_field_seed>> setting.
 
-Note: The tracking value is updated only after the PIT+search_after run completes, it won't update during the search_after pagination. This is to allow use of slices.
+Note: The tracking value is updated after each page is read and at the end of each Point in Time. In case of a crash the last saved value will be used so some duplication of data can occur. For this reason the use of unique document IDs for each event is recommended in the downstream destination.
 
 [id="plugins-{type}s-{plugin}-tracking_field_seed"]
 ===== `tracking_field_seed`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -126,12 +126,14 @@ Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-last_run_metadata_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-response_type>> |<<string,string>>, one of `["hits","aggregations"]`|No
 | <<plugins-{type}s-{plugin}-request_timeout_seconds>> | <<number,number>>|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-schedule_overlap>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-scroll>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-search_api>> |<<string,string>>, one of `["auto", "search_after", "scroll"]`|No
 | <<plugins-{type}s-{plugin}-size>> |<<number,number>>|No
@@ -151,6 +153,8 @@ Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
 | <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>, one of `["full", "none"]`|No
 | <<plugins-{type}s-{plugin}-socket_timeout_seconds>> | <<number,number>>|No
 | <<plugins-{type}s-{plugin}-target>> | {logstash-ref}/field-references-deepdive.html[field reference] | No
+| <<plugins-{type}s-{plugin}-tracking_field>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-tracking_field_seed>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-retries>> | <<number,number>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 |=======================================================================
@@ -330,6 +334,15 @@ Check out {ref}/api-conventions.html#api-multi-index[Multi Indices
 documentation] in the Elasticsearch documentation for info on
 referencing multiple indices.
 
+[id="plugins-{type}s-{plugin}-last_run_metadata_path"]
+===== `last_run_metadata_path`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The path to store the last observed value of the tracking field, when used.
+By default this file is stored as `<path.data>/plugins/inputs/elasticsearch/<pipeline.id>.last_run`.
+
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password`
 
@@ -409,6 +422,19 @@ for example: "* * * * *" (execute query every minute, on the minute)
 
 There is no schedule by default. If no schedule is given, then the statement is run
 exactly once.
+
+[id="plugins-{type}s-{plugin}-schedule_overlap"]
+===== `schedule_overlap`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+Whether to allow queuing of a scheduled run if a run is occurring.
+While this is ideal for ensuring a new run happens immediatelly after the previous on finishes if there
+is a lot of work to do, but given the queue is unbounded it may lead to an out of memory over long periods of time
+if the queue grows continuously.
+
+When in doubt, set `schedule_overlap` to false (it may become the default value in the future).
 
 [id="plugins-{type}s-{plugin}-scroll"]
 ===== `scroll`
@@ -622,6 +648,25 @@ When the `target` is set to a field reference, the `_source` of the hit is place
 This option can be useful to avoid populating unknown fields when a downstream schema such as ECS is enforced.
 It is also possible to target an entry in the event's metadata, which will be available during event processing but not exported to your outputs (e.g., `target \=> "[@metadata][_source]"`).
 
+[id="plugins-{type}s-{plugin}-tracking_field"]
+===== `tracking_field`
+
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+Which field from the last event of a previous run will be used a cursor value for the following run.
+The value of this field is injected into each query if the query uses the placeholder `:last_value`.
+For the first query after a pipeline is started, the value used is either read from <<last_run_metadata_path>> file,
+or taken from <<tracking_field_seed>> setting.
+
+[id="plugins-{type}s-{plugin}-tracking_field_seed"]
+===== `tracking_field_seed`
+
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+The starting value for the <<tracking_field>> if there is no <<last_run_metadata_path>> already.
+For a nanosecond timestamp based field, a suggested seed value something like `1980-01-01T23:59:59.999999999Z`.
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -114,9 +114,10 @@ Examples include:
 * avoiding the need to re-process the entire result set of a long query after an unplanned restart
 * grabbing only new data from an index instead of processing the entire set on each job.
 
-For this, the Elasticsearch input plugin provides the <<plugins-{type}s-{plugin}-tracking_field>> and <<plugins-{type}s-{plugin}-tracking_field_seed>> options.
-When <<plugins-{type}s-{plugin}-tracking_field>> is set, the plugin will record the value of that field for the last document retrieved in a run into
-a file (location defaults to <<plugins-{type}s-{plugin}-last_run_metadata_path>>).
+The Elasticsearch input plugin provides the <<plugins-{type}s-{plugin}-tracking_field>> and <<plugins-{type}s-{plugin}-tracking_field_seed>> options.
+When <<plugins-{type}s-{plugin}-tracking_field>> is set, the plugin records the value of that field for the last document retrieved in a run into
+a file. 
+(The file location defaults to <<plugins-{type}s-{plugin}-last_run_metadata_path>>.)
 
 The user can then inject this value in the query using the placeholder `:last_value`. The value will be injected into the query
 before execution, and the updated after the query completes if new data was found.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -108,9 +108,11 @@ Common causes are:
 
 NOTE: experimental:[] `tracking_field` and related settings are experimental and subject to change in the future
 
-It is sometimes desirable to track the value of a particular field between two jobs:
-* avoid re-processing the entire result set of a long query after an unplanned restart
-* only grab new data from an index instead of processing the entire set on each job
+Some uses cases require tracking the value of a particular field between two jobs.
+Examples include:
+
+* avoiding the need to re-process the entire result set of a long query after an unplanned restart
+* grabbing only new data from an index instead of processing the entire set on each job.
 
 For this, the Elasticsearch input plugin provides the <<plugins-{type}s-{plugin}-tracking_field>> and <<plugins-{type}s-{plugin}-tracking_field_seed>> options.
 When <<plugins-{type}s-{plugin}-tracking_field>> is set, the plugin will record the value of that field for the last document retrieved in a run into

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -63,11 +63,11 @@ a file (location defaults to <<plugins-{type}s-{plugin}-last_run_metadata_path>>
 The user can then inject this value in the query using the placeholder `:last_value`. The value will be injected into the query
 before execution, and the updated after the query completes, assuming new data was found.
 
-The plugin also offers another placeholder called `:present` used to inject the nano-second based
-
 This feature works best when:
 * the query sorts by the tracking field
 * the field type has enough resolution so that two events are unlikely to have the same value for the field
+
+The plugin also offers another placeholder called `:present` used to inject the nano-second based value of "now-30s".
 
 A suggestion is to use a tracking field that has nanosecond second precision, like
 https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html[date nanoseconds] field type.
@@ -456,7 +456,7 @@ referencing multiple indices.
   * There is no default value for this setting.
 
 The path to store the last observed value of the tracking field, when used.
-By default this file is stored as `<path.data>/plugins/inputs/elasticsearch/last_run_value`.
+By default this file is stored as `<path.data>/plugins/inputs/elasticsearch/<pipeline_id>/last_run_value`.
 
 This setting should point to file, not a directory, and Logstash must have read+write access to this file.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -137,7 +137,7 @@ If the tracking field is of this data type, you can use an extra placeholder cal
 This placeholder is useful as the right-hand side of a range filter, allowing the collection of
 new data but leaving partially-searchable bulk request data to the next scheduled job.
 
-id="plugins-{type}s-{plugin}-tracking-sample"]
+[id="plugins-{type}s-{plugin}-tracking-sample"]
 ===== Sample configuration: Track field value across runs
 
 This section contains a series of steps to help you set up the "tailing" of data being written to a set of indices, using a date nanosecond field added by an Elasticsearch ingest pipeline and the `tracking_field` capability of this plugin.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -782,10 +782,11 @@ Note: The tracking value is updated after each page is read and at the end of ea
 ===== `tracking_field_seed`
 
 * Value type is <<string,string>>
-* There is no default value for this setting.
+* Default value is `"1970-01-01T00:00:00.000000000Z"`
 
 The starting value for the <<plugins-{type}s-{plugin}-tracking_field>> if there is no <<plugins-{type}s-{plugin}-last_run_metadata_path>> already.
-For a nanosecond timestamp based field, a suggested seed value something like `1980-01-01T23:59:59.999999999Z`.
+This field defaults to the nanosecond precision ISO8601 representation of `epoch`, or "1970-01-01T00:00:00.000000000Z", given nano-second precision timestamps are the
+most reliable data format to use for this feature.
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -119,8 +119,8 @@ When <<plugins-{type}s-{plugin}-tracking_field>> is set, the plugin records the 
 a file. 
 (The file location defaults to <<plugins-{type}s-{plugin}-last_run_metadata_path>>.)
 
-The user can then inject this value in the query using the placeholder `:last_value`. The value will be injected into the query
-before execution, and the updated after the query completes if new data was found.
+You can then inject this value in the query using the placeholder `:last_value`. 
+The value will be injected into the query before execution, and then updated after the query completes if new data was found.
 
 This feature works best when:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -124,20 +124,22 @@ The value will be injected into the query before execution, and then updated aft
 
 This feature works best when:
 
-. the query sorts by the tracking field;
-. the timestamp field is added by {es};
-. the field type has enough resolution so that two events are unlikely to have the same value.
+* the query sorts by the tracking field,
+* the timestamp field is added by {es}, and
+* the field type has enough resolution so that two events are unlikely to have the same value.
 
-It is recommended to use a tracking field whose type is https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html[date nanoseconds].
-If the tracking field is of this data type, an extra placeholder called `:present` can be used to inject the nano-second based value of "now-30s".
+Consider using a tracking field whose type is https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html[date nanoseconds].
+If the tracking field is of this data type, you can use an extra placeholder called `:present` to inject the nano-second based value of "now-30s".
 This placeholder is useful as the right-hand side of a range filter, allowing the collection of
-new data but leaving partially-searcheable bulk request data to the next scheduled job.
+new data but leaving partially-searchable bulk request data to the next scheduled job.
 
-Below is a series of steps to help set up the "tailing" of data being written to a set of indices, using a date nanosecond field
-added by an Elasticsearch ingest pipeline, and the `tracking_field` capability of this plugin.
+id="plugins-{type}s-{plugin}-tracking-sample"]
+===== Sample configuration: Track field value across runs
 
-. create ingest pipeline that adds Elasticsearch's `_ingest.timestamp` field to the documents as `event.ingested`:
+This section contains a series of steps to help you set up the "tailing" of data being written to a set of indices, using a date nanosecond field added by an Elasticsearch ingest pipeline and the `tracking_field` capability of this plugin.
 
+. Create ingest pipeline that adds Elasticsearch's `_ingest.timestamp` field to the documents as `event.ingested`:
++
 [source, json]
     PUT _ingest/pipeline/my-pipeline
     {
@@ -152,8 +154,8 @@ added by an Elasticsearch ingest pipeline, and the `tracking_field` capability o
     }
 
 [start=2]
-. create an index mapping where the tracking field is of date nanosecond type and invokes the defined pipeline:
-
+. Create an index mapping where the tracking field is of date nanosecond type and invokes the defined pipeline:
++
 [source, json]
     PUT /_template/my_template
     {
@@ -176,8 +178,8 @@ added by an Elasticsearch ingest pipeline, and the `tracking_field` capability o
     }
 
 [start=3]
-. define a query that looks at all data of the indices, sorted by the tracking field, and with a range filter since the last value seen until present:
-
+. Define a query that looks at all data of the indices, sorted by the tracking field, and with a range filter since the last value seen until present:
++
 [source,json]
 {
   "query": {
@@ -200,8 +202,8 @@ added by an Elasticsearch ingest pipeline, and the `tracking_field` capability o
 }
 
 [start=4]
-. configure the Elasticsearch input to query the indices with the query defined above, every minute, and track the `event.ingested` field:
-
+. Configure the Elasticsearch input to query the indices with the query defined above, every minute, and track the `event.ingested` field:
++
 [source, ruby]
     input {
       elasticsearch {
@@ -217,11 +219,12 @@ added by an Elasticsearch ingest pipeline, and the `tracking_field` capability o
       }
     }
 
-With this setup, as new documents are indexed an `test-*` index, the next scheduled run will:
+With this sample setup, new documents are indexed into a `test-*` index.
+The next scheduled run:
 
-. select all new documents since the last observed value of the tracking field;
-. use {ref}/point-in-time-api.html#point-in-time-api[Point in time (PIT)] + {ref}/paginate-search-results.html#search-after[Search after] to paginate through all the data;
-. update the value of the field at the end of the pagination.
+* selects all new documents since the last observed value of the tracking field,
+* uses {ref}/point-in-time-api.html#point-in-time-api[Point in time (PIT)] + {ref}/paginate-search-results.html#search-after[Search after] to paginate through all the data, and
+* updates the value of the field at the end of the pagination.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Elasticsearch Input configuration options

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -107,6 +107,11 @@ Common causes are:
 ==== Tracking a field's value across runs
 
 NOTE: experimental:[] `tracking_field` and related settings are experimental and subject to change in the future
+.Technical Preview: Tracking a field's value
+****
+The feature that allows tracking a field's value across runs is in _Technical Preview_.
+Configuration options and implementation details are subject to change in minor releases without being preceded by deprecation warnings.
+****
 
 Some uses cases require tracking the value of a particular field between two jobs.
 Examples include:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -74,7 +74,7 @@ https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html[
 
 A good use case for this feature is to track new data in an index, which can be achieved by:
 
-1. create ingest pipeline that adds Elasticsearch's `_ingest.timestamp` field to the documents as `event.ingested`:
+. create ingest pipeline that adds Elasticsearch's `_ingest.timestamp` field to the documents as `event.ingested`:
 
 [source, json]
     PUT _ingest/pipeline/my-pipeline
@@ -89,8 +89,8 @@ A good use case for this feature is to track new data in an index, which can be 
       ]
     }
 
-
-2. create an index mapping where the tracking field is of date nanosecond type and invokes the defined pipeline:
+[start=2]
+. create an index mapping where the tracking field is of date nanosecond type and invokes the defined pipeline:
 
 [source, json]
     PUT /_template/my_template
@@ -113,7 +113,8 @@ A good use case for this feature is to track new data in an index, which can be 
       }
     }
 
-3. define a query that looks at all data of the indices, sorted by the tracking field, and with a range filter since the last value seen until present:
+[start=3]
+. define a query that looks at all data of the indices, sorted by the tracking field, and with a range filter since the last value seen until present:
 
 [source,json]
 {
@@ -136,7 +137,8 @@ A good use case for this feature is to track new data in an index, which can be 
   ]
 }
 
-4. configure the Elasticsearch input to query the indices with the query defined above, every minute, and track the `event.ingested` field:
+[start=4]
+. configure the Elasticsearch input to query the indices with the query defined above, every minute, and track the `event.ingested` field:
 
 [source, ruby]
     input {
@@ -157,9 +159,9 @@ A good use case for this feature is to track new data in an index, which can be 
 
 With this setup, as new documents are indexed an `test-*` index, the next scheduled run will:
 
-1. select all new documents since the last observed value of the tracking field;
-2. use PIT+search_after to paginate through all the data;
-3. update the value of the field at the end of the pagination.
+. select all new documents since the last observed value of the tracking field;
+. use PIT+search_after to paginate through all the data;
+. update the value of the field at the end of the pagination.
 
 [id="plugins-{type}s-{plugin}-scheduling"]
 ==== Scheduling

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -365,6 +365,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def get_query_object
+    return @query unless @cursor_tracker
     injected_query = @cursor_tracker.inject_cursor(@query)
     @logger.debug("new query is #{injected_query}")
     query_object = LogStash::Json.load(injected_query)

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -365,10 +365,13 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def get_query_object
-    return @query unless @cursor_tracker
-    injected_query = @cursor_tracker.inject_cursor(@query)
-    @logger.debug("new query is #{injected_query}")
-    query_object = LogStash::Json.load(injected_query)
+    if @cursor_tracker
+      query = @cursor_tracker.inject_cursor(@query)
+      @logger.debug("new query is #{injected_query}")
+    else
+      query = @query
+    end
+    LogStash::Json.load(query)
   end
 
   ##

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -127,7 +127,6 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
   # Enable tracking the value of a given field to be used as a cursor
   # TODO: main concerns
-  #       * schedule overlap needs to be disabled (hardcoded as enabled)
   #       * using anything other than _event.timestamp easily leads to data loss
   #       * the first "synchronization run can take a long time"
   #       * checkpointing is only safe to do after each run (not per document)
@@ -269,7 +268,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
   # Allow scheduled runs to overlap (enabled by default). Setting to false will
   # only start a new scheduled run after the previous one completes.
-  config :schedule_overlap, :validate => :string
+  config :schedule_overlap, :validate => :boolean
 
   # If set, the _source of each hit will be added nested under the target instead of at the top-level
   config :target, :validate => :field_reference

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -126,13 +126,13 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   config :slices, :validate => :number
 
   # Enable tracking the value of a given field to be used as a cursor
-  # TODO: main concerns
+  # Main concerns:
   #       * using anything other than _event.timestamp easily leads to data loss
   #       * the first "synchronization run can take a long time"
   config :tracking_field, :validate => :string
 
   # Define the initial seed value of the tracking_field
-  config :tracking_field_seed, :validate => :string
+  config :tracking_field_seed, :validate => :string, :default => "1970-01-01T00:00:00.000000000Z"
 
   # The location of where the tracking field value will be stored
   # The value is persisted after each scheduled run (and not per result)
@@ -686,7 +686,6 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
       raise ConfigurationError.new("The `tracking_field` feature can only be used with `search_after` non-aggregation queries")
     end
 
-    @tracking_field_seed ||= Time.now.utc.iso8601
     @cursor_tracker = CursorTracker.new(last_run_metadata_path: last_run_metadata_path,
                                         tracking_field: @tracking_field,
                                         tracking_field_seed: @tracking_field_seed)

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -129,7 +129,6 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   # TODO: main concerns
   #       * using anything other than _event.timestamp easily leads to data loss
   #       * the first "synchronization run can take a long time"
-  #       * checkpointing is only safe to do after each run (not per document)
   config :tracking_field, :validate => :string
 
   # Define the initial seed value of the tracking_field

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -366,7 +366,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   def get_query_object
     if @cursor_tracker
       query = @cursor_tracker.inject_cursor(@query)
-      @logger.debug("new query is #{injected_query}")
+      @logger.debug("new query is #{query}")
     else
       query = @query
     end

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -379,7 +379,11 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     event = event_from_hit(hit, root_field)
     decorate(event)
     output_queue << event
-    @cursor_tracker.record_last_value(event)
+    record_last_value(event)
+  end
+
+  def record_last_value(event)
+    @cursor_tracker.record_last_value(event) if @tracking_field
   end
 
   def event_from_hit(hit, root_field)
@@ -688,14 +692,11 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def setup_cursor_tracker
-    if @tracking_field
-      @tracking_field_seed ||= Time.now.utc.iso8601
-      @cursor_tracker = CursorTracker.new(last_run_metadata_path: @last_run_metadata_path,
-                                          tracking_field: @tracking_field,
-                                          tracking_field_seed: @tracking_field_seed)
-    else
-      @cursor_tracker = NoopCursorTracker.new
-    end
+    return unless @tracking_field
+    @tracking_field_seed ||= Time.now.utc.iso8601
+    @cursor_tracker = CursorTracker.new(last_run_metadata_path: @last_run_metadata_path,
+                                        tracking_field: @tracking_field,
+                                        tracking_field_seed: @tracking_field_seed)
   end
 
   module URIOrEmptyValidator

--- a/lib/logstash/inputs/elasticsearch/aggregation.rb
+++ b/lib/logstash/inputs/elasticsearch/aggregation.rb
@@ -13,13 +13,7 @@ module LogStash
           @plugin_params = plugin.params
 
           @size = @plugin_params["size"]
-          @query = @plugin_params["query"]
           @retries = @plugin_params["retries"]
-          @agg_options = {
-            :index => @plugin_params["index"],
-            :size  => 0
-          }.merge(:body => @query)
-
           @plugin = plugin
         end
 
@@ -33,10 +27,18 @@ module LogStash
           false
         end
 
-        def do_run(output_queue)
+        def aggregation_options(query_object)
+          {
+            :index => @index,
+            :size => 0,
+            :body => query_object
+          }
+        end
+
+        def do_run(output_queue, query_object)
           logger.info("Aggregation starting")
           r = retryable(AGGREGATION_JOB) do
-            @client.search(@agg_options)
+            @client.search(aggregation_options(query_object))
           end
           @plugin.push_hit(r, output_queue, 'aggregations') if r
         end

--- a/lib/logstash/inputs/elasticsearch/aggregation.rb
+++ b/lib/logstash/inputs/elasticsearch/aggregation.rb
@@ -12,6 +12,7 @@ module LogStash
           @client = client
           @plugin_params = plugin.params
 
+          @index = @plugin_params["index"]
           @size = @plugin_params["size"]
           @retries = @plugin_params["retries"]
           @plugin = plugin

--- a/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
+++ b/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
@@ -8,8 +8,6 @@ module LogStash; module Inputs; class Elasticsearch
 
     def initialize(last_run_metadata_path:, tracking_field:, tracking_field_seed:)
       @last_run_metadata_path = last_run_metadata_path
-      @last_run_metadata_path ||= ::File.join(LogStash::SETTINGS.get_value("path.data"), "plugins", "inputs", "elasticsearch", "last_run_value")
-      FileUtils.mkdir_p ::File.dirname(@last_run_metadata_path)
       @last_value_hashmap = Java::java.util.concurrent.ConcurrentHashMap.new
       @last_value = IO.read(@last_run_metadata_path) rescue nil || tracking_field_seed
       @tracking_field = tracking_field

--- a/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
+++ b/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
@@ -35,6 +35,7 @@ module LogStash; module Inputs; class Elasticsearch
 
     def converge_last_value
       return if @last_value_hashmap.empty?
+      # TODO this implicitly assumes that the way to converge the value among slices is to pick the highest and we can't assume that
       new_last_value = @last_value_hashmap.reduceValues(1, lambda { |v1, v2| Time.parse(v1) < Time.parse(v2) ? v2 : v1 })
       return if new_last_value == @last_value
       @last_value = new_last_value

--- a/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
+++ b/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
@@ -1,17 +1,6 @@
 require 'fileutils'
 
 module LogStash; module Inputs; class Elasticsearch
-  class NoopCursorTracker
-    include LogStash::Util::Loggable
-    def checkpoint_cursor; end
-
-    def converge_last_value; end
-
-    def record_last_value(event); end
-
-    def inject_cursor(query_json); return query_json; end
-  end
-
   class CursorTracker
     include LogStash::Util::Loggable
 

--- a/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
+++ b/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
@@ -48,9 +48,13 @@ module LogStash; module Inputs; class Elasticsearch
 
     def inject_cursor(query_json)
       # ":present" means "now - 30s" to avoid grabbing partially visible data in the PIT
-      result = query_json.gsub(":last_value", @last_value.to_s).gsub(":present", Java::java.time.Instant.now.minusSeconds(30).to_s)
+      result = query_json.gsub(":last_value", @last_value.to_s).gsub(":present", now_in_nanos)
       logger.debug("inject_cursor: injected values for ':last_value' and ':present'", :query => result)
       result
+    end
+
+    def now_in_nanos
+      Java::java.time.Instant.now.minusSeconds(30).to_s
     end
   end
 end; end; end

--- a/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
+++ b/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
@@ -49,7 +49,7 @@ module LogStash; module Inputs; class Elasticsearch
     end
 
     def inject_cursor(query_json)
-      query_json.gsub(":last_value", @last_value)
+      query_json.gsub(":last_value", @last_value.to_s)
     end
   end
 end; end; end

--- a/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
+++ b/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
@@ -1,0 +1,54 @@
+require 'fileutils'
+
+module LogStash; module Inputs; class Elasticsearch
+  class NoopCursorTracker
+    include LogStash::Util::Loggable
+    def checkpoint_cursor; end
+
+    def converge_last_value; end
+
+    def record_last_value(event); end
+
+    def inject_cursor(query_json); return query_json; end
+  end
+
+  class CursorTracker
+    include LogStash::Util::Loggable
+
+    attr_reader :last_value
+
+    def initialize(last_run_metadata_path:, tracking_field:, tracking_field_seed:)
+      @last_run_metadata_path = last_run_metadata_path
+      @last_run_metadata_path ||= ::File.join(LogStash::SETTINGS.get_value("path.data"), "plugins", "inputs", "elasticsearch", "last_run_value")
+      FileUtils.mkdir_p ::File.dirname(@last_run_metadata_path)
+      @last_value_hashmap = Java::java.util.concurrent.ConcurrentHashMap.new
+      @last_value = IO.read(@last_run_metadata_path) rescue nil || tracking_field_seed
+      @tracking_field = tracking_field
+      logger.info "Starting value for cursor field \"#{@tracking_field}\": #{@last_value}"
+    end
+
+    def checkpoint_cursor
+      converge_last_value
+      IO.write(@last_run_metadata_path, @last_value)
+      @last_value_hashmap.clear
+    end
+
+    def converge_last_value
+      return if @last_value_hashmap.empty?
+      new_last_value = @last_value_hashmap.reduceValues(1, lambda { |v1, v2| Time.parse(v1) < Time.parse(v2) ? v2 : v1 })
+      return if new_last_value == @last_value
+      @last_value = new_last_value
+      logger.info "New cursor value for field \"#{@tracking_field}\" is: #{new_last_value}"
+    end
+
+    def record_last_value(event)
+      value = event.get(@tracking_field)
+      logger.trace? && logger.trace("storing last_value if #{@tracking_field} for #{Thread.current.object_id}: #{value}")
+      @last_value_hashmap.put(Thread.current.object_id, value)
+    end
+
+    def inject_cursor(query_json)
+      query_json.gsub(":last_value", @last_value)
+    end
+  end
+end; end; end

--- a/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
+++ b/lib/logstash/inputs/elasticsearch/cursor_tracker.rb
@@ -46,12 +46,12 @@ module LogStash; module Inputs; class Elasticsearch
 
     def inject_cursor(query_json)
       # ":present" means "now - 30s" to avoid grabbing partially visible data in the PIT
-      result = query_json.gsub(":last_value", @last_value.to_s).gsub(":present", now_in_nanos)
+      result = query_json.gsub(":last_value", @last_value.to_s).gsub(":present", now_minus_30s)
       logger.debug("inject_cursor: injected values for ':last_value' and ':present'", :query => result)
       result
     end
 
-    def now_in_nanos
+    def now_minus_30s
       Java::java.time.Instant.now.minusSeconds(30).to_s
     end
   end

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -24,11 +24,8 @@ module LogStash
         def do_run(output_queue, query)
           @query = query
 
-          if @slices.nil? || @slices <= 1
-            retryable_search(output_queue)
-          else
-            retryable_slice_search(output_queue)
-          end
+          return retryable_search(output_queue) if @slices.nil? || @slices <= 1
+          retryable_slice_search(output_queue)
         end
 
         def retryable(job_name, &block)

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -123,6 +123,13 @@ module LogStash
         PIT_JOB = "create point in time (PIT)"
         SEARCH_AFTER_JOB = "search_after paginated search"
 
+        attr_accessor :cursor_tracker
+
+        def do_run(output_queue, query)
+          super(output_queue, query)
+          @cursor_tracker.checkpoint_cursor(intermediate: false) if @cursor_tracker
+        end
+
         def pit?(id)
           !!id&.is_a?(String)
         end
@@ -192,6 +199,8 @@ module LogStash
               next_page(pit_id: pit_id, search_after: search_after, slice_id: slice_id)
             end
           end
+
+          @cursor_tracker.checkpoint_cursor(intermediate: true) if @cursor_tracker
 
           logger.info("Query completed", log_details)
         end

--- a/lib/logstash/inputs/elasticsearch/paginated_search.rb
+++ b/lib/logstash/inputs/elasticsearch/paginated_search.rb
@@ -21,10 +21,14 @@ module LogStash
           @pipeline_id = plugin.pipeline_id
         end
 
-        def do_run(output_queue)
-          return retryable_search(output_queue) if @slices.nil? || @slices <= 1
+        def do_run(output_queue, query)
+          @query = query
 
-          retryable_slice_search(output_queue)
+          if @slices.nil? || @slices <= 1
+            retryable_search(output_queue)
+          else
+            retryable_slice_search(output_queue)
+          end
         end
 
         def retryable(job_name, &block)

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '5.0.2'
+  s.version         = '5.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/cursor_tracker_spec.rb
+++ b/spec/inputs/cursor_tracker_spec.rb
@@ -58,7 +58,7 @@ describe LogStash::Inputs::Elasticsearch::CursorTracker do
     before(:each) do
       subject.record_last_value(LogStash::Event.new("my_field" => new_value))
       subject.checkpoint_cursor(intermediate: false)
-      allow(subject).to receive(:now_in_nanos).and_return(fake_now)
+      allow(subject).to receive(:now_minus_30s).and_return(fake_now)
     end
 
     it "injects the value of the cursor into json query if it contains :last_value" do

--- a/spec/inputs/cursor_tracker_spec.rb
+++ b/spec/inputs/cursor_tracker_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/devutils/rspec/shared_examples"
+require "logstash/inputs/elasticsearch"
 require "logstash/inputs/elasticsearch/cursor_tracker"
 
 describe LogStash::Inputs::Elasticsearch::CursorTracker do

--- a/spec/inputs/cursor_tracker_spec.rb
+++ b/spec/inputs/cursor_tracker_spec.rb
@@ -24,6 +24,7 @@ describe LogStash::Inputs::Elasticsearch::CursorTracker do
 
   describe "checkpoint_cursor" do
     before(:each) do
+      subject.checkpoint_cursor(intermediate: false) # store seed value
       [
         Thread.new(subject) {|subject| subject.record_last_value(LogStash::Event.new("my_field" => "2025-01-03T23:59:59.999999999Z")) },
         Thread.new(subject) {|subject| subject.record_last_value(LogStash::Event.new("my_field" => "2025-01-01T23:59:59.999999999Z")) },
@@ -31,14 +32,14 @@ describe LogStash::Inputs::Elasticsearch::CursorTracker do
       ].each(&:join)
     end
     context "when doing intermediate checkpoint" do
-      before(:each) { subject.checkpoint_cursor(intermediate: true) }
       it "persists the smallest value" do
+        subject.checkpoint_cursor(intermediate: true)
         expect(IO.read(last_run_metadata_path)).to eq("2025-01-01T23:59:59.999999999Z")
       end
     end
     context "when doing non-intermediate checkpoint" do
-      before(:each) { subject.checkpoint_cursor(intermediate: false) }
       it "persists the largest value" do
+        subject.checkpoint_cursor(intermediate: false)
         expect(IO.read(last_run_metadata_path)).to eq("2025-01-03T23:59:59.999999999Z")
       end
     end

--- a/spec/inputs/cursor_tracker_spec.rb
+++ b/spec/inputs/cursor_tracker_spec.rb
@@ -1,0 +1,70 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/devutils/rspec/shared_examples"
+require "logstash/inputs/elasticsearch/cursor_tracker"
+
+describe LogStash::Inputs::Elasticsearch::CursorTracker do
+
+  let(:last_run_metadata_path) { Tempfile.new('cursor_tracker_testing').path }
+  let(:tracking_field_seed) { "1980-01-01T23:59:59.999999999Z" }
+  let(:options) do
+    {
+      :last_run_metadata_path => last_run_metadata_path,
+      :tracking_field => "my_field",
+      :tracking_field_seed => tracking_field_seed
+    }
+  end
+
+  subject { described_class.new(**options) }
+
+  it "creating a class works" do
+    expect(subject).to be_a described_class
+  end
+
+  describe "checkpoint_cursor" do
+    before(:each) do
+      [
+        Thread.new(subject) {|subject| subject.record_last_value(LogStash::Event.new("my_field" => "2025-01-03T23:59:59.999999999Z")) },
+        Thread.new(subject) {|subject| subject.record_last_value(LogStash::Event.new("my_field" => "2025-01-01T23:59:59.999999999Z")) },
+        Thread.new(subject) {|subject| subject.record_last_value(LogStash::Event.new("my_field" => "2025-01-02T23:59:59.999999999Z")) },
+      ].each(&:join)
+    end
+    context "when doing intermediate checkpoint" do
+      before(:each) { subject.checkpoint_cursor(intermediate: true) }
+      it "persists the smallest value" do
+        expect(IO.read(last_run_metadata_path)).to eq("2025-01-01T23:59:59.999999999Z")
+      end
+    end
+    context "when doing non-intermediate checkpoint" do
+      before(:each) { subject.checkpoint_cursor(intermediate: false) }
+      it "persists the largest value" do
+        expect(IO.read(last_run_metadata_path)).to eq("2025-01-03T23:59:59.999999999Z")
+      end
+    end
+  end
+
+  describe "inject_cursor" do
+    let(:new_value) { "2025-01-03T23:59:59.999999999Z" }
+    let(:fake_now) { "2026-09-19T23:59:59.999999999Z" }
+
+    let(:query) do
+      %q[
+      { "query": { "range": { "event.ingested": { "gt": :last_value, "lt": :present}}}, "sort": [ { "event.ingested": {"order": "asc", "format": "strict_date_optional_time_nanos", "numeric_type" : "date_nanos" } } ] }
+      ]
+    end
+
+    before(:each) do
+      subject.record_last_value(LogStash::Event.new("my_field" => new_value))
+      subject.checkpoint_cursor(intermediate: false)
+      allow(subject).to receive(:now_in_nanos).and_return(fake_now)
+    end
+
+    it "injects the value of the cursor into json query if it contains :last_value" do
+      expect(subject.inject_cursor(query)).to match(/#{new_value}/)
+    end
+
+    it "injects current time into json query if it contains :present" do
+      expect(subject.inject_cursor(query)).to match(/#{fake_now}/)
+    end
+  end
+end

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -1165,7 +1165,7 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
 
     context "when there's an exception" do
       before(:each) do
-        allow(client).to receive(:search).and_raise RuntimeError
+        allow(client).to receive(:search).and_raise RuntimeError.new("test exception")
       end
       it 'produces no events' do
         plugin.run queue
@@ -1309,6 +1309,10 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
     end
 
     let(:mock_queue) { double('queue', :<< => nil) }
+
+    before(:each) do
+      plugin.send(:setup_cursor_tracker)
+    end
 
     it 'pushes a generated event to the queue' do
       plugin.send(:push_hit, hit, mock_queue)

--- a/spec/inputs/integration/elasticsearch_spec.rb
+++ b/spec/inputs/integration/elasticsearch_spec.rb
@@ -76,6 +76,14 @@ describe LogStash::Inputs::Elasticsearch do
     shared_examples 'secured_elasticsearch' do
       it_behaves_like 'an elasticsearch index plugin'
 
+      let(:unauth_exception_class) do
+        begin
+          Elasticsearch::Transport::Transport::Errors::Unauthorized
+        rescue
+          Elastic::Transport::Transport::Errors::Unauthorized
+        end
+      end
+
       context "incorrect auth credentials" do
 
         let(:config) do
@@ -85,7 +93,7 @@ describe LogStash::Inputs::Elasticsearch do
         let(:queue) { [] }
 
         it "fails to run the plugin" do
-          expect { plugin.register }.to raise_error Elasticsearch::Transport::Transport::Errors::Unauthorized
+          expect { plugin.register }.to raise_error unauth_exception_class
         end
       end
     end


### PR DESCRIPTION
With this change it's possible to configure a "tracking_field" whose value is injected into the query using the `:last_value` keyword, and a `:present` field that represents `now - 30s`.

Example configuration:

```
input {
  elasticsearch {
    id => tail
    hosts => [ 'https://host...']
    api_key => "..."
    index => "my_data"
    query => '{ "query": { "range": { "event.ingested": { "gt": ":last_value", "lt": ":present"}}}, "sort": [ { "event.ingested": {"order": "asc", "format": "strict_date_optional_time_nanos", "numeric_type" : "date_nanos" } } ] }'
    tracking_field => "[event][ingested]"
    tracking_field_seed => "1980-01-01T23:59:59.999999999Z"
    slices => 5
    schedule => '* * * * *'
    schedule_overlap => false
  }
}
output {
  elasticsearch { .. }
}
```

To test this, follow the guidance on the doc changes from this PR on how to set up Elasticsearch. Or you can use a script that prepares the index/ingest_pipeline and writes documents to ES like https://gist.github.com/jsvd/6ea96197078d906362227494e0c542dc

resolves #184 
resolves #93 