### PR TITLE
Doc: Update link to resolve to target content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.20.3
+  - [DOC] Update link to bypass redirect, resolving directly to correct content  [#206](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/206)
+
 ## 4.20.2
   - fix case when aggregation returns an error [#204](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/204)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -301,10 +301,10 @@ can be either IP, HOST, IP:port, or HOST:port. The port defaults to
   * Value type is <<string,string>>
   * Default value is `"logstash-*"`
 
-The index or alias to search. See {ref}/multi-index.html[Multi Indices
-documentation] in the Elasticsearch documentation for more information on how to
-reference multiple indices.
-
+The index or alias to search. 
+Check out {ref}/api-conventions.html#api-multi-index[Multi Indices
+documentation] in the Elasticsearch documentation for info on
+referencing multiple indices.
 
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password` 

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.20.2'
+  s.version         = '4.20.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The "Multi-target syntax" link resolves to a [redirect page](https://www.elastic.co/guide/en/elasticsearch/reference/master/multi-index.html), requiring users to make another click to get to the [content](https://www.elastic.co/guide/en/elasticsearch/reference/master/api-conventions.html#api-multi-index). Yikes! 

<img width="745" alt="Screen Shot 2024-06-11 at 5 58 57 PM" src="https://github.com/logstash-plugins/logstash-input-elasticsearch/assets/35154725/537aec75-4215-400f-a3fd-1ef6a7feee9f">

This PR updates the link to resolve to the correct content. 
 
