### PR TITLE
Set x-elastic-product-origin header for ES requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.20.5
+  - Add `x-elastic-product-origin` header to Elasticsearch requests [#211](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/211)
+
 ## 4.20.4
   - Fix issue where the `index` parameter was being ignored when using `response_type => aggregations` [#209](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/209)
 

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -271,6 +271,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
   BUILD_FLAVOR_SERVERLESS = 'serverless'.freeze
   DEFAULT_EAV_HEADER = { "Elastic-Api-Version" => "2023-10-31" }.freeze
+  INTERNAL_ORIGIN_HEADER = { 'x-elastic-product-origin' => 'logstash-input-elasticsearch'}.freeze
 
   def initialize(params={})
     super(params)
@@ -300,6 +301,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     fill_user_password_from_cloud_auth
 
     transport_options = {:headers => {}}
+    transport_options[:headers].merge!(INTERNAL_ORIGIN_HEADER)
     transport_options[:headers].merge!(setup_basic_auth(user, password))
     transport_options[:headers].merge!(setup_api_key(api_key))
     transport_options[:headers].merge!({'user-agent' => prepare_user_agent()})

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '4.20.4'
+  s.version         = '4.20.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -50,6 +50,12 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
         client = plugin.send(:client)
         expect( extract_transport(client).options[:transport_options][:headers] ).not_to match hash_including("Elastic-Api-Version" => "2023-10-31")
       end
+
+      it "sets an x-elastic-product-origin header identifying this as an internal plugin request" do
+        plugin.register
+        client = plugin.send(:client)
+        expect( extract_transport(client).options[:transport_options][:headers] ).to match hash_including("x-elastic-product-origin"=>"logstash-input-elasticsearch")
+      end
     end
 
     context "against not authentic Elasticsearch" do
@@ -89,6 +95,12 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
           plugin.register
           client = plugin.send(:client)
           expect( extract_transport(client).options[:transport_options][:headers] ).to match hash_including("Elastic-Api-Version" => "2023-10-31")
+        end
+
+        it "sets an x-elastic-product-origin header identifying this as an internal plugin request" do
+          plugin.register
+          client = plugin.send(:client)
+          expect( extract_transport(client).options[:transport_options][:headers] ).to match hash_including("x-elastic-product-origin"=>"logstash-input-elasticsearch")
         end
       end
     end


### PR DESCRIPTION
This commit updates the `Elasticsearch::Client` used to make requests to ES to send along a header identifying the request as originating from an internal component.

Closes https://github.com/logstash-plugins/logstash-input-elasticsearch/issues/212