### PR TITLE
Update .travis.yml to properly separate testing stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ before_install:
 jobs:
   include:
     - stage: "Integration Tests"
-    - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=7.current
+      env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=7.current
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.previous
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.next
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.future
     - stage: "Secure Integration Tests"
-    - env: SECURE_INTEGRATION=true INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current SNAPSHOT=true
+      env: SECURE_INTEGRATION=true INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current SNAPSHOT=true
     - env: SECURE_INTEGRATION=true INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=7.current
     - env: SECURE_INTEGRATION=true INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=7.current ES_SSL_SUPPORTED_PROTOCOLS=TLSv1.3


### PR DESCRIPTION
If we don't include the `env` matrix row in the stage definition entry, then the previous entry is put under the next stage.

We can see this where a non integration test shows up in the integration test stage:

Build: https://app.travis-ci.com/github/logstash-plugins/logstash-input-elasticsearch/builds/273186251

Image:
<img width="1166" alt="Screenshot 2024-11-20 at 18 24 41" src="https://github.com/user-attachments/assets/5f14288b-3c93-47e0-8948-1d6bef71d451">


