### PR TITLE
elasticsearch-ruby client upgrade to 8.x, initial step.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.2
+  - Replaces `elasticsearch-transport` v7 ruby client with `elastic-transport` v8 [#222](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/222)
+
 ## 5.0.1
   - Fix: prevent plugin crash when hits contain illegal structure [#218](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/218)
     - When a hit cannot be converted to an event, the input now emits an event tagged with `_elasticsearch_input_failure` with an `[event][original]` containing a JSON-encoded string representation of the entire hit.

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -13,7 +13,7 @@ require "logstash/plugin_mixins/normalize_config_support"
 require "base64"
 
 require "elasticsearch"
-require "elasticsearch/transport/transport/http/manticore"
+require "elastic/transport/transport/http/manticore"
 require_relative "elasticsearch/patches/_elasticsearch_transport_http_manticore"
 require_relative "elasticsearch/patches/_elasticsearch_transport_connections_selector"
 
@@ -316,7 +316,7 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
     @client_options = {
       :hosts => hosts,
       :transport_options => transport_options,
-      :transport_class => ::Elasticsearch::Transport::Transport::HTTP::Manticore,
+      :transport_class => ::Elastic::Transport::Transport::HTTP::Manticore,
       :ssl => ssl_options
     }
 

--- a/lib/logstash/inputs/elasticsearch/patches/_elasticsearch_transport_connections_selector.rb
+++ b/lib/logstash/inputs/elasticsearch/patches/_elasticsearch_transport_connections_selector.rb
@@ -1,14 +1,14 @@
 require 'elasticsearch'
-require 'elasticsearch/transport/transport/connections/selector'
+require 'elastic/transport/transport/connections/selector'
 
-if Gem.loaded_specs['elasticsearch-transport'].version < Gem::Version.new("7.2.0")
+if Gem.loaded_specs['elastic-transport'].version < Gem::Version.new("7.2.0")
   # elasticsearch-transport versions prior to 7.2.0 suffered of a race condition on accessing
   # the connection pool. This issue was fixed (in 7.2.0) with
   # https://github.com/elastic/elasticsearch-ruby/commit/15f9d78591a6e8823948494d94b15b0ca38819d1
   #
   # This plugin, at the moment, is using elasticsearch >= 5.0.5
   # When this requirement ceases, this patch could be removed.
-  module Elasticsearch
+  module Elastic
     module Transport
       module Transport
         module Connections

--- a/lib/logstash/inputs/elasticsearch/patches/_elasticsearch_transport_http_manticore.rb
+++ b/lib/logstash/inputs/elasticsearch/patches/_elasticsearch_transport_http_manticore.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
 require "elasticsearch"
-require "elasticsearch/transport/transport/http/manticore"
+require "elastic/transport/transport/http/manticore"
 
-es_client_version = Gem.loaded_specs['elasticsearch-transport'].version
+es_client_version = Gem.loaded_specs['elastic-transport'].version
 if es_client_version >= Gem::Version.new('7.2') && es_client_version < Gem::Version.new('7.16')
   # elasticsearch-transport 7.2.0 - 7.14.0 had a bug where setting http headers
   #   ES::Client.new ..., transport_options: { headers: { 'Authorization' => ... } }
@@ -11,7 +11,7 @@ if es_client_version >= Gem::Version.new('7.2') && es_client_version < Gem::Vers
   # NOTE: needs to be idempotent as filter ES plugin might apply the same patch!
   #
   # @private
-  module Elasticsearch
+  module Elastic
     module Transport
       module Transport
         module HTTP

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://www.elastic.co/logstash"
   s.require_paths = ["lib"]
 
   # Files
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-mixin-scheduler", '~> 1.0'
 
   s.add_runtime_dependency 'elasticsearch', '>= 7.17.9'
+  # s.add_runtime_dependency 'elasticsearch', '~> 8'
   s.add_runtime_dependency 'logstash-mixin-ca_trusted_fingerprint_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-normalize_config_support', '~>1.0'
 

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '5.0.1'
+  s.version         = '5.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -26,8 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'
   s.add_runtime_dependency "logstash-mixin-scheduler", '~> 1.0'
 
-  s.add_runtime_dependency 'elasticsearch', '>= 7.17.9'
-  # s.add_runtime_dependency 'elasticsearch', '~> 8'
+  s.add_runtime_dependency 'elasticsearch', '~> 8'
   s.add_runtime_dependency 'logstash-mixin-ca_trusted_fingerprint_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-normalize_config_support', '~>1.0'
 

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -93,7 +93,7 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
         before do
           allow(Elasticsearch::Client).to receive(:new).and_return(es_client)
           allow(es_client).to receive(:info).and_raise(
-            Elasticsearch::Transport::Transport::Errors::BadRequest.new
+            Elastic::Transport::Transport::Errors::BadRequest.new
           )
         end
 
@@ -745,7 +745,8 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
         plugin.register
         client = plugin.send(:client)
 
-        expect( client.transport.instance_variable_get(:@seeds) ).to eql [{
+        puts "Transport client: #{client.transport.inspect}"
+        expect( client.transport.instance_variable_get(:@hosts) ).to eql [{
                                                                               :scheme => "https",
                                                                               :host => "ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io",
                                                                               :port => 9243,

--- a/spec/inputs/integration/elasticsearch_spec.rb
+++ b/spec/inputs/integration/elasticsearch_spec.rb
@@ -85,7 +85,7 @@ describe LogStash::Inputs::Elasticsearch do
         let(:queue) { [] }
 
         it "fails to run the plugin" do
-          expect { plugin.register }.to raise_error Elasticsearch::Transport::Transport::Errors::Unauthorized
+          expect { plugin.register }.to raise_error Elastic::Transport::Transport::Errors::Unauthorized
         end
       end
     end


### PR DESCRIPTION
### Description

Replaces `elasticsearch-transport-v7` client with new `elastic-transport-v8` client.