### PR TITLE
Adds elastic-transport client support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.2
+  - Adds elastic-transport support [#223](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/223)
+
 ## 5.0.1
   - Fix: prevent plugin crash when hits contain illegal structure [#218](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/218)
     - When a hit cannot be converted to an event, the input now emits an event tagged with `_elasticsearch_input_failure` with an `[event][original]` containing a JSON-encoded string representation of the entire hit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.0.2
-  - Add elastic-transport client support [#223](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/223)
+  - Add elastic-transport client support used in elasticsearch-ruby 8.x [#223](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/223)
 
 ## 5.0.1
   - Fix: prevent plugin crash when hits contain illegal structure [#218](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.0.2
-  - Adds elastic-transport support [#223](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/223)
+  - Add elastic-transport client support [#223](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/223)
 
 ## 5.0.1
   - Fix: prevent plugin crash when hits contain illegal structure [#218](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/218)

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -13,6 +13,7 @@ require "logstash/plugin_mixins/normalize_config_support"
 require "base64"
 
 require "elasticsearch"
+require "manticore"
 
 # .Compatibility Note
 # [NOTE]

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -641,6 +641,10 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def get_transport_client_class
+    # LS-core includes `elasticsearch` gem. The gem is composed of two separate gems: `elasticsearch-api` and `elasticsearch-transport`
+    # And now `elasticsearch-transport` is old, instead we have `elastic-transport`.
+    # LS-core updated `elasticsearch` > 8: https://github.com/elastic/logstash/pull/17161
+    # Following source bits are for the compatibility to support both `elasticsearch-transport` and `elastic-transport` gems
     require "elasticsearch/transport/transport/http/manticore"
     require_relative "elasticsearch/patches/_elasticsearch_transport_http_manticore"
     require_relative "elasticsearch/patches/_elasticsearch_transport_connections_selector"

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '5.0.1'
+  s.version         = '5.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://elastic.co/logstash"
   s.require_paths = ["lib"]
 
   # Files

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-mixin-validator_support", '~> 1.0'
   s.add_runtime_dependency "logstash-mixin-scheduler", '~> 1.0'
 
-  s.add_runtime_dependency 'elasticsearch', '>= 7.17.9'
+  s.add_runtime_dependency 'elasticsearch', '>= 7.17.9', '< 9'
   s.add_runtime_dependency 'logstash-mixin-ca_trusted_fingerprint_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-normalize_config_support', '~>1.0'
 


### PR DESCRIPTION
 Adds elastic-transport client support where opens LS-core a way to start using newer ES ruby client.

FYI: failed [Test plugin docs](https://github.com/logstash-plugins/logstash-input-elasticsearch/actions/runs/13647730753?pr=223) CI is not related to this change.