### PR TITLE
Support both, encoded and non encoded api-key formats on plugin configuration

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -563,10 +563,18 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def setup_api_key(api_key)
-    return {} unless (api_key && api_key.value)
+    return {} unless (api_key&.value)
 
-    token = ::Base64.strict_encode64(api_key.value)
+    token = is_base64?(api_key.value) ?  api_key.value : Base64.strict_encode64(api_key.value)
     { 'Authorization' => "ApiKey #{token}" }
+  end
+
+  def is_base64?(string)
+    begin
+      string == Base64.strict_encode64(Base64.strict_decode64(string))
+    rescue ArgumentError
+      false
+    end
   end
 
   def prepare_user_agent

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -823,14 +823,26 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
       end
 
       context "with ssl" do
-        let(:config) { super().merge({ 'api_key' => LogStash::Util::Password.new('foo:bar'), "ssl_enabled" => true }) }
+        let(:config) { super().merge("ssl_enabled" => true) }
+        encoded_api_key = Base64.strict_encode64('foo:bar')
 
-        it "should set authorization" do
-          plugin.register
-          client = plugin.send(:client)
-          auth_header = extract_transport(client).options[:transport_options][:headers]['Authorization']
+        scenarios = {
+          'with non-encoded api-key' => LogStash::Util::Password.new('foo:bar'),
+          'with encoded api-key' => LogStash::Util::Password.new(encoded_api_key)
+        }
 
-          expect( auth_header ).to eql "ApiKey #{Base64.strict_encode64('foo:bar')}"
+        scenarios.each do |description, api_key_value|
+          context description do
+            let(:config) { super().merge('api_key' => api_key_value) }
+
+            it "should set authorization" do
+              plugin.register
+              client = plugin.send(:client)
+              auth_header = extract_transport(client).options[:transport_options][:headers]['Authorization']
+
+              expect(auth_header).to eql "ApiKey #{encoded_api_key}"
+            end
+          end
         end
 
         context 'user also set' do


### PR DESCRIPTION
Avoid double-encoding opaque Elasticsearch API keys.

Previously, API keys that were already in encoded format were incorrectly re-encoded, causing connection failures. This update ensures that only raw keys are encoded, supporting both opaque and id:api-key formats without issue.

Closes #236 

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
