### PR TITLE
raise error when using tracking_field and search_api is not "search_after" 

### DIFF
--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -708,9 +708,8 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
 
   def setup_cursor_tracker
     return unless @tracking_field
-    return unless @query_executor.is_a?(LogStash::Inputs::Elasticsearch::SearchAfter)
 
-    if @resolved_search_api != "search_after" || @response_type != "hits"
+    if @resolved_search_api != "search_after" || @response_type != "hits" || !@query_executor.is_a?(LogStash::Inputs::Elasticsearch::SearchAfter)
       raise ConfigurationError.new("The `tracking_field` feature can only be used with `search_after` non-aggregation queries")
     end
 


### PR DESCRIPTION
Bug Report Summary
When using tracking_field with logstash-input-elasticsearch and the default scroll API, Logstash sends the literal string :last_value instead of the resolved timestamp. This causes Elasticsearch to fail parsing with:

        failed to parse date field [:last_value] with format [strict_date_optional_time_nanos]
        caused_by: Text ':last_value' could not be parsed at index 0

Workaround
Use search_api => "search_after" instead of the default scroll.

System has to notify about it somehow. I've spent a lot of time while i figured it out.