### PR TITLE
Remove rufus cheduler.

### DIFF
--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -39,7 +39,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'cabin', ['~> 0.6']
   s.add_development_dependency 'webrick'
-
-  # 3.8.0 has breaking changes WRT to joining, which break our specs
-  s.add_development_dependency 'rufus-scheduler', '~> 3.0.9'
 end


### PR DESCRIPTION
Removes rufus-scheduler development dependency, new version will be consumed through logstash-mixin-scheduler, comatible with jruby 10, extra details - https://github.com/elastic/logstash/pull/14260