### PR TITLE
[Doc] search_after authorization for aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.2.2
-  - [DOC] Note that `search_after` requires permissions on underlying indices/data streams, not aliases [#TBD](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/TBD)
+  - [DOC] Note that `search_after` requires permissions on underlying indices/data streams, not aliases [#251](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/TBD)
 
 ## 5.2.1
   - Added support for encoded and non encoded api-key formats on plugin configuration [#237](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/237)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.2
+  - [DOC] Note that `search_after` requires permissions on underlying indices/data streams, not aliases [#TBD](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/TBD)
+
 ## 5.2.1
   - Added support for encoded and non encoded api-key formats on plugin configuration [#237](https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/237)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -120,10 +120,10 @@ Examples include:
 
 The Elasticsearch input plugin provides the <<plugins-{type}s-{plugin}-tracking_field>> and <<plugins-{type}s-{plugin}-tracking_field_seed>> options.
 When <<plugins-{type}s-{plugin}-tracking_field>> is set, the plugin records the value of that field for the last document retrieved in a run into
-a file. 
+a file.
 (The file location defaults to <<plugins-{type}s-{plugin}-last_run_metadata_path>>.)
 
-You can then inject this value in the query using the placeholder `:last_value`. 
+You can then inject this value in the query using the placeholder `:last_value`.
 The value will be injected into the query before execution, and then updated after the query completes if new data was found.
 
 This feature works best when:
@@ -705,6 +705,8 @@ With `auto` the plugin uses the `search_after` parameter for Elasticsearch versi
 The query requires at least one `sort` field, as described in the <<plugins-{type}s-{plugin}-query>> parameter.
 
 `scroll` uses {ref}/paginate-search-results.html#scroll-search-results[scroll] API to search, which is no longer recommended.
+
+NOTE: When using `search_after`, read permissions on aliases alone are insufficient. Permissions must be granted on the underlying indices or data streams.
 
 [id="plugins-{type}s-{plugin}-size"]
 ===== `size`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -706,7 +706,7 @@ The query requires at least one `sort` field, as described in the <<plugins-{typ
 
 `scroll` uses {ref}/paginate-search-results.html#scroll-search-results[scroll] API to search, which is no longer recommended.
 
-NOTE: When using `search_after`, read permissions on aliases alone are insufficient. Permissions must be granted on the underlying indices or data streams.
+NOTE: `search_after` needs read permissions on the underlying indices or data streams. Permissions on aliases alone are not enough.
 
 [id="plugins-{type}s-{plugin}-size"]
 ===== `size`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -706,7 +706,7 @@ The query requires at least one `sort` field, as described in the <<plugins-{typ
 
 `scroll` uses {ref}/paginate-search-results.html#scroll-search-results[scroll] API to search, which is no longer recommended.
 
-NOTE: `search_after` needs read permissions on the underlying indices or data streams. Permissions on aliases alone are not enough.
+NOTE: When using `search_after`, including using `auto` on  Elasticsearch 8+, permissions to read data aliases alone will not work: permissions are also needed on the underlying indices or data streams.
 
 [id="plugins-{type}s-{plugin}-size"]
 ===== `size`

--- a/logstash-input-elasticsearch.gemspec
+++ b/logstash-input-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-elasticsearch'
-  s.version         = '5.2.1'
+  s.version         = '5.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads query results from an Elasticsearch cluster"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adds a NOTE under `search_api` explaining that when using `search_after`, read permissions on aliases alone are not enough. Permissions must be granted on the underlying indices or data streams.

Bumps version to 5.2.2.

Closes #250