### PR TITLE
Support Base64 and Elastic Cloud org level api keys.

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -401,10 +401,12 @@ input plugins.
 
 Authenticate using Elasticsearch API key. Note that this option also requires enabling the <<plugins-{type}s-{plugin}-ssl_enabled>> option.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the
+The format is `id:api_key`, where `id` and `api_key` are as returned by the
 Elasticsearch
 {ref}/security-api-create-api-key.html[Create
-API key API].
+API key API]. The base64-encoded form of that pair is also accepted, as is an
+https://www.elastic.co/docs/deploy-manage/api-keys/elastic-cloud-api-keys[Elastic Cloud API key]
+(prefixed with `essu_`), which is used as-is.
 
 [id="plugins-{type}s-{plugin}-ca_trusted_fingerprint"]
 ===== `ca_trusted_fingerprint`

--- a/lib/logstash/inputs/elasticsearch.rb
+++ b/lib/logstash/inputs/elasticsearch.rb
@@ -215,7 +215,8 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   config :cloud_auth, :validate => :password
 
   # Authenticate using Elasticsearch API key.
-  # format is id:api_key (as returned by https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key])
+  # Format is either the `id:api_key` pair (as returned by https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key]),
+  # its base64-encoded form, or an https://www.elastic.co/docs/deploy-manage/api-keys/elastic-cloud-api-keys[Elastic Cloud API key] (prefixed with `essu_`) can be used.
   config :api_key, :validate => :password
 
   # Set the address of a forward HTTP proxy.
@@ -599,10 +600,38 @@ class LogStash::Inputs::Elasticsearch < LogStash::Inputs::Base
   end
 
   def setup_api_key(api_key)
-    return {} unless (api_key && api_key.value)
+    return {} unless (api_key&.value)
 
-    token = ::Base64.strict_encode64(api_key.value)
+    token = resolve_api_key(api_key.value)
     { 'Authorization' => "ApiKey #{token}" }
+  end
+
+  # Resolves the `api_key` value into the credential used in the
+  # `Authorization: ApiKey` header. An already base64-encoded key and an Elastic
+  # Cloud API key are used as-is; a raw `id:api_key` pair is base64-encoded. An
+  # unrecognized value is rejected so a malformed key surfaces at startup rather
+  # than as a later authentication failure.
+  def resolve_api_key(key_value)
+    if base64?(key_value) || cloud_api_key?(key_value)
+      key_value
+    elsif key_value.match?(/\A[^:]+:[^:]+\z/)
+      Base64.strict_encode64(key_value)
+    else
+      raise LogStash::ConfigurationError, "Invalid api_key format. Expected a base64-encoded key, an 'id:api_key' pair, or a Cloud API key (essu_ prefix)."
+    end
+  end
+
+  # Elastic Cloud API keys (such as the unified Serverless keys) are opaque
+  # tokens prefixed with `essu_` that Elasticsearch accepts verbatim in the
+  # `Authorization: ApiKey` header, with no base64 encoding.
+  def cloud_api_key?(string)
+    string.match?(/\Aessu_.+/)
+  end
+
+  def base64?(string)
+    string == Base64.strict_encode64(Base64.strict_decode64(string))
+  rescue ArgumentError
+    false
   end
 
   def prepare_user_agent

--- a/spec/inputs/elasticsearch_spec.rb
+++ b/spec/inputs/elasticsearch_spec.rb
@@ -810,14 +810,50 @@ describe LogStash::Inputs::Elasticsearch, :ecs_compatibility_support do
       end
 
       context "with ssl" do
-        let(:config) { super().merge({ 'api_key' => LogStash::Util::Password.new('foo:bar'), "ssl_enabled" => true }) }
+        let(:api_key_value) { nil }
+        let(:config) { super().merge("ssl_enabled" => true, 'api_key' => LogStash::Util::Password.new(api_key_value)) }
+        let(:encoded_api_key) { Base64.strict_encode64('foo:bar') }
 
-        it "should set authorization" do
-          plugin.register
-          client = plugin.send(:client)
-          auth_header = extract_transport(client).options[:transport_options][:headers]['Authorization']
+        shared_examples "a plugin that sets the ApiKey authorization header" do
+          it "correctly sets the Authorization header" do
+            plugin.register
+            client = plugin.send(:client)
+            auth_header = extract_transport(client).options[:transport_options][:headers]['Authorization']
 
-          expect( auth_header ).to eql "ApiKey #{Base64.strict_encode64('foo:bar')}"
+            expect(auth_header).to eql("ApiKey #{encoded_api_key}")
+          end
+        end
+
+        context "with a non-encoded API key" do
+          let(:api_key_value) { "foo:bar" }
+          it_behaves_like "a plugin that sets the ApiKey authorization header"
+        end
+
+        context "with an encoded API key" do
+          let(:api_key_value) { encoded_api_key }
+          it_behaves_like "a plugin that sets the ApiKey authorization header"
+        end
+
+        context "with an Elastic Cloud API key (essu_ prefix)" do
+          # The suffix is intentionally not canonical base64: a Cloud key is opaque
+          # and must be forwarded verbatim regardless of its payload encoding.
+          let(:api_key_value) { "essu_VFZGblZreFhTekJ4ZDB4M2NHUnZRMEU2YzNWd1pYSnpaV055WlhRPQ==AAAAAAAA" }
+
+          it "sets the Authorization header verbatim without re-encoding" do
+            plugin.register
+            client = plugin.send(:client)
+            auth_header = extract_transport(client).options[:transport_options][:headers]['Authorization']
+
+            expect(auth_header).to eql("ApiKey #{api_key_value}")
+          end
+        end
+
+        context "with an unrecognized api_key format" do
+          let(:api_key_value) { "not-a-valid-key" }
+
+          it "fails registration with a configuration error" do
+            expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /Invalid api_key format/)
+          end
         end
 
         context 'user also set' do


### PR DESCRIPTION
## Align API key handling with main branch

Backports the `api_key` format handling from the `main` branch to `4.x`, which ships with Logstash 8.19.x.

### Changes

The `api_key` option now accepts three formats:

- **`id:api_key`** — raw pair, base64-encoded automatically by the plugin (existing behavior)
- **Base64-encoded value** — passed through as-is, avoiding double-encoding (e.g. the `encoded` field returned by the Create API Key API, available since ES 7.16.0)
- **Elastic Cloud API key (`essu_` prefix)** — passed through verbatim, enabling authentication against Serverless projects using organization-level Cloud API keys

Unrecognized formats are rejected at startup with a clear `ConfigurationError`, so misconfigured keys surface immediately rather than as opaque authentication failures at runtime.

Follows https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/274 implementation
